### PR TITLE
add skills and update README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,50 +1,34 @@
-# Cloudflare Skills for Claude
+# Cloudflare Skills
 
-A collection of Claude Skills for building on the Cloudflare developer platform.
+A collection of [Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) for building on Cloudflare, Workers, the Agents SDK, and the wider Cloudflare Developer Platform.
+
+## Installing Skills
+
+These skills work with any agent that supports the Agent Skills standard, including Claude Code, OpenCode, OpenAI Codex, and Pi.
+
+Copy the skill directories you need to the appropriate location for your agent:
+
+| Agent | Skill Directory | Docs |
+|-------|-----------------|------|
+| Claude Code | `~/.claude/skills/` | [docs](https://code.claude.com/docs/en/skills) |
+| OpenCode | `~/.config/opencode/skill/` | [docs](https://opencode.ai/docs/skills/) |
+| OpenAI Codex | `~/.codex/skills/` | [docs](https://developers.openai.com/codex/skills/) |
+| Pi | `~/.pi/agent/skills/` | [docs](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent#skills) |
 
 ## Skills
 
-### building-mcp-server-on-cloudflare
-
-Build remote Model Context Protocol (MCP) servers on Cloudflare with tools, OAuth authentication, and production deployment.
-
-**Triggers:** "build MCP server", "create MCP tools", "remote MCP", "deploy MCP", "OAuth to MCP", "MCP authentication"
-
-**Contents:**
-- `SKILL.md` - Core guide for building MCP servers
-- `references/examples.md` - Official templates and boilerplates
-- `references/oauth-setup.md` - Security and OAuth configuration
-- `references/troubleshooting.md` - Common issues and fixes
-
-### building-ai-agent-on-cloudflare
-
-Build AI agents using the Cloudflare Agents SDK with state management, real-time WebSockets, scheduled tasks, and tool integration.
-
-**Triggers:** "build an agent", "AI agent", "chat agent", "stateful agent", "Agents SDK", "real-time AI", "WebSocket AI"
-
-**Contents:**
-- `SKILL.md` - Core guide for building agents
-- `references/examples.md` - Official templates and reference implementations
-- `references/agent-patterns.md` - Tool calling, RAG, multi-agent orchestration
-- `references/state-patterns.md` - State management strategies
-- `references/troubleshooting.md` - Common issues and fixes
+| Skill | Useful for | Directory |
+|-------|------------|-----------|
+| agents-sdk | Building stateful AI agents with state, scheduling, RPC, MCP servers, email, and streaming chat | `agents-sdk/` |
+| durable-objects | Stateful coordination (chat rooms, games, booking), RPC, SQLite, alarms, WebSockets | `durable-objects/` |
+| wrangler | Deploying and managing Workers, KV, R2, D1, Vectorize, Queues, Workflows | `wrangler/` |
+| web-perf | Auditing Core Web Vitals (FCP, LCP, TBT, CLS), render-blocking resources, network chains | `web-perf/` |
+| building-mcp-server-on-cloudflare | Building remote MCP servers with tools, OAuth, and deployment | `building-mcp-server-on-cloudflare/` |
+| building-ai-agent-on-cloudflare | Building AI agents with state, WebSockets, and tool integration | `building-ai-agent-on-cloudflare/` |
 
 ## Usage
 
-These skills are designed for use with Claude. When a user's request matches the trigger phrases, Claude will use the relevant skill to provide accurate, up-to-date guidance for building on Cloudflare.
-
-## Structure
-
-Each skill follows the standard layout:
-
-```
-skill-name/
-├── SKILL.md              # Main skill file with YAML frontmatter
-└── references/           # Supporting documentation
-    ├── examples.md
-    ├── patterns.md
-    └── troubleshooting.md
-```
+When a request matches a skill's triggers, the agent loads and applies the relevant skill to provide accurate, up-to-date guidance.
 
 ## Resources
 

--- a/agents-sdk/SKILL.md
+++ b/agents-sdk/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: agents-sdk
+description: Build stateful AI agents using the Cloudflare Agents SDK. Load when creating agents with persistent state, scheduling, RPC, MCP servers, email handling, or streaming chat. Covers Agent class, AIChatAgent, state management, and Code Mode for reduced token usage.
+---
+
+# Cloudflare Agents SDK
+
+Build persistent, stateful AI agents on Cloudflare Workers using the `agents` npm package.
+
+## FIRST: Verify Installation
+
+```bash
+npm install agents
+```
+
+Agents require a binding in `wrangler.jsonc`:
+
+```jsonc
+{
+  "durable_objects": {
+    // "class_name" must match your Agent class name exactly
+    "bindings": [{ "name": "Counter", "class_name": "Counter" }]
+  },
+  "migrations": [
+    // Required: list all Agent classes for SQLite storage
+    { "tag": "v1", "new_sqlite_classes": ["Counter"] }
+  ]
+}
+```
+
+## Choosing an Agent Type
+
+| Use Case | Base Class | Package |
+|----------|------------|---------|
+| Custom state + RPC, no chat | `Agent` | `agents` |
+| Chat with message persistence | `AIChatAgent` | `@cloudflare/ai-chat` |
+| Building an MCP server | `McpAgent` | `agents/mcp` |
+
+## Key Concepts
+
+- **Agent** base class provides state, scheduling, RPC, MCP, and email capabilities
+- **AIChatAgent** adds streaming chat with automatic message persistence and resumable streams
+- **Code Mode** generates executable code instead of tool calls—reduces token usage significantly
+- **this.state / this.setState()** - automatic persistence to SQLite, broadcasts to clients
+- **this.schedule()** - schedule tasks at Date, delay (seconds), or cron expression
+- **@callable** decorator - expose methods to clients via WebSocket RPC
+
+## Quick Reference
+
+| Task | API |
+|------|-----|
+| Persist state | `this.setState({ count: 1 })` |
+| Read state | `this.state.count` |
+| Schedule task | `this.schedule(60, "taskMethod", payload)` |
+| Schedule cron | `this.schedule("0 * * * *", "hourlyTask")` |
+| Cancel schedule | `this.cancelSchedule(id)` |
+| Queue task | `this.queue("processItem", payload)` |
+| SQL query | `` this.sql`SELECT * FROM users WHERE id = ${id}` `` |
+| RPC method | `@callable() async myMethod() { ... }` |
+| Streaming RPC | `@callable({ streaming: true }) async stream(res) { ... }` |
+
+## Minimal Agent
+
+```typescript
+import { Agent, routeAgentRequest, callable } from "agents";
+
+type State = { count: number };
+
+export class Counter extends Agent<Env, State> {
+  initialState = { count: 0 };
+
+  @callable()
+  increment() {
+    this.setState({ count: this.state.count + 1 });
+    return this.state.count;
+  }
+}
+
+export default {
+  fetch: (req, env) => routeAgentRequest(req, env) ?? new Response("Not found", { status: 404 })
+};
+```
+
+## Streaming Chat Agent
+
+Use `AIChatAgent` for chat with automatic message persistence and resumable streaming.
+
+**Install additional dependencies first:**
+```bash
+npm install @cloudflare/ai-chat ai @ai-sdk/openai
+```
+
+**Add wrangler.jsonc config** (same pattern as base Agent):
+```jsonc
+{
+  "durable_objects": {
+    "bindings": [{ "name": "Chat", "class_name": "Chat" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["Chat"] }]
+}
+```
+
+```typescript
+import { AIChatAgent } from "@cloudflare/ai-chat";
+import { routeAgentRequest } from "agents";
+import { streamText, convertToModelMessages } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+export class Chat extends AIChatAgent<Env> {
+  async onChatMessage(onFinish) {
+    const result = streamText({
+      model: openai("gpt-4o"),
+      messages: await convertToModelMessages(this.messages),
+      onFinish
+    });
+    return result.toUIMessageStreamResponse();
+  }
+}
+
+export default {
+  fetch: (req, env) => routeAgentRequest(req, env) ?? new Response("Not found", { status: 404 })
+};
+```
+
+**Client** (React):
+```tsx
+import { useAgent } from "agents/react";
+import { useAgentChat } from "@cloudflare/ai-chat/react";
+
+const agent = useAgent({ agent: "Chat", name: "my-chat" });
+const { messages, input, handleSubmit } = useAgentChat({ agent });
+```
+
+## Detailed References
+
+- **[references/state-scheduling.md](references/state-scheduling.md)** - State persistence, scheduling, queues
+- **[references/streaming-chat.md](references/streaming-chat.md)** - AIChatAgent, resumable streams, UI patterns
+- **[references/codemode.md](references/codemode.md)** - Generate code instead of tool calls (token savings)
+- **[references/mcp.md](references/mcp.md)** - MCP server integration
+- **[references/email.md](references/email.md)** - Email routing and handling
+
+## When to Use Code Mode
+
+Code Mode generates executable JavaScript instead of making individual tool calls. Use it when:
+
+- Chaining multiple tool calls in sequence
+- Complex conditional logic across tools
+- MCP server orchestration (multiple servers)
+- Token budget is constrained
+
+See [references/codemode.md](references/codemode.md) for setup and examples.
+
+## Best Practices
+
+1. **Prefer streaming**: Use `streamText` and `toUIMessageStreamResponse()` for chat
+2. **Use AIChatAgent for chat**: Handles message persistence and resumable streams automatically
+3. **Type your state**: `Agent<Env, State>` ensures type safety for `this.state`
+4. **Use @callable for RPC**: Cleaner than manual WebSocket message handling
+5. **Code Mode for complex workflows**: Reduces round-trips and token usage
+6. **Schedule vs Queue**: Use `schedule()` for time-based, `queue()` for sequential processing

--- a/agents-sdk/references/codemode.md
+++ b/agents-sdk/references/codemode.md
@@ -1,0 +1,207 @@
+# Code Mode (Experimental)
+
+Code Mode generates executable JavaScript instead of making individual tool calls. This significantly reduces token usage and enables complex multi-tool workflows.
+
+## Why Code Mode?
+
+Traditional tool calling:
+- One tool call per LLM request
+- Multiple round-trips for chained operations
+- High token usage for complex workflows
+
+Code Mode:
+- LLM generates code that orchestrates multiple tools
+- Single execution for complex workflows
+- Self-debugging and error recovery
+- Ideal for MCP server orchestration
+
+## Setup
+
+### 1. Wrangler Config
+
+```jsonc
+{
+  "name": "my-agent-worker",
+  "compatibility_flags": ["experimental", "enable_ctx_exports"],
+  "durable_objects": {
+    // "class_name" must match your Agent class name exactly
+    "bindings": [{ "name": "MyAgent", "class_name": "MyAgent" }]
+  },
+  "migrations": [
+    // Required: list all Agent classes for SQLite storage
+    { "tag": "v1", "new_sqlite_classes": ["MyAgent"] }
+  ],
+  "services": [
+    {
+      "binding": "globalOutbound",
+      // "service" must match "name" above
+      "service": "my-agent-worker",
+      "entrypoint": "globalOutbound"
+    },
+    {
+      "binding": "CodeModeProxy",
+      "service": "my-agent-worker",
+      "entrypoint": "CodeModeProxy"
+    }
+  ],
+  "worker_loaders": [{ "binding": "LOADER" }]
+}
+```
+
+### 2. Export Required Classes
+
+```typescript
+// Export the proxy for tool execution (required for codemode)
+export { CodeModeProxy } from "@cloudflare/codemode/ai";
+
+// Define outbound fetch handler for security filtering
+export const globalOutbound = {
+  fetch: async (input: string | URL | RequestInfo, init?: RequestInit) => {
+    const url = new URL(
+      typeof input === "string"
+        ? input
+        : typeof input === "object" && "url" in input
+          ? input.url
+          : input.toString()
+    );
+    // Block certain domains if needed
+    if (url.hostname === "blocked.example.com") {
+      return new Response("Not allowed", { status: 403 });
+    }
+    return fetch(input, init);
+  }
+};
+```
+
+### 3. Install Dependencies
+
+```bash
+npm install @cloudflare/codemode ai @ai-sdk/openai zod
+```
+
+### 4. Use Code Mode in Agent
+
+```typescript
+import { Agent } from "agents";
+import { experimental_codemode as codemode } from "@cloudflare/codemode/ai";
+import { streamText, tool, convertToModelMessages } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { env } from "cloudflare:workers";
+import { z } from "zod";
+
+const tools = {
+  getWeather: tool({
+    description: "Get weather for a location",
+    parameters: z.object({ location: z.string() }),
+    execute: async ({ location }) => `Weather: ${location} 72°F`
+  }),
+  sendEmail: tool({
+    description: "Send an email",
+    parameters: z.object({ to: z.string(), subject: z.string(), body: z.string() }),
+    execute: async ({ to, subject, body }) => `Email sent to ${to}`
+  })
+};
+
+export class MyAgent extends Agent<Env, State> {
+  tools = {};
+
+  // Method called by codemode proxy
+  callTool(functionName: string, args: unknown[]) {
+    return this.tools[functionName]?.execute?.(args, {
+      abortSignal: new AbortController().signal,
+      toolCallId: "codemode",
+      messages: []
+    });
+  }
+
+  async onChatMessage() {
+    this.tools = { ...tools, ...this.mcp.getAITools() };
+
+    const { prompt, tools: wrappedTools } = await codemode({
+      prompt: "You are a helpful assistant...",
+      tools: this.tools,
+      globalOutbound: env.globalOutbound,
+      loader: env.LOADER,
+      proxy: this.ctx.exports.CodeModeProxy({
+        props: {
+          binding: "MyAgent",  // Class name
+          name: this.name,     // Instance name
+          callback: "callTool" // Method to call
+        }
+      })
+    });
+
+    const result = streamText({
+      system: prompt,
+      model: openai("gpt-4o"),
+      messages: await convertToModelMessages(this.state.messages),
+      tools: wrappedTools  // Use wrapped tools, not original
+    });
+
+    // ... handle stream
+  }
+}
+```
+
+## Generated Code Example
+
+When user asks "Check the weather in NYC and email me the forecast", codemode generates:
+
+```javascript
+async function executeTask() {
+  const weather = await codemode.getWeather({ location: "NYC" });
+  
+  await codemode.sendEmail({
+    to: "user@example.com",
+    subject: "NYC Weather Forecast",
+    body: `Current weather: ${weather}`
+  });
+  
+  return { success: true, weather };
+}
+```
+
+## MCP Server Orchestration
+
+Code Mode excels at orchestrating multiple MCP servers:
+
+```javascript
+async function executeTask() {
+  // Query file system MCP
+  const files = await codemode.listFiles({ path: "/projects" });
+  
+  // Query database MCP
+  const status = await codemode.queryDatabase({
+    query: "SELECT * FROM projects WHERE name = ?",
+    params: [files[0].name]
+  });
+  
+  // Conditional logic based on results
+  if (status.length === 0) {
+    await codemode.createTask({
+      title: `Review: ${files[0].name}`,
+      priority: "high"
+    });
+  }
+  
+  return { files, status };
+}
+```
+
+## When to Use
+
+| Scenario | Use Code Mode? |
+|----------|---------------|
+| Single tool call | No |
+| Chained tool calls | Yes |
+| Conditional logic across tools | Yes |
+| MCP multi-server workflows | Yes |
+| Token budget constrained | Yes |
+| Simple Q&A chat | No |
+
+## Limitations
+
+- Experimental - API may change
+- Requires Cloudflare Workers
+- JavaScript execution only (Python planned)
+- Requires additional wrangler config

--- a/agents-sdk/references/email.md
+++ b/agents-sdk/references/email.md
@@ -1,0 +1,119 @@
+# Email Handling
+
+Agents can receive and reply to emails via Cloudflare Email Routing.
+
+## Wrangler Config
+
+```jsonc
+{
+  "durable_objects": {
+    "bindings": [{ "name": "EmailAgent", "class_name": "EmailAgent" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["EmailAgent"] }],
+  "send_email": [
+    { "name": "SEB", "destination_address": "reply@yourdomain.com" }
+  ]
+}
+```
+
+Configure Email Routing in Cloudflare dashboard to forward to your Worker.
+
+## Implement onEmail
+
+```typescript
+import { Agent, AgentEmail } from "agents";
+import PostalMime from "postal-mime";
+
+type State = { emails: Array<{ from: string; subject: string; text: string; timestamp: Date }> };
+
+export class EmailAgent extends Agent<Env, State> {
+  initialState: State = { emails: [] };
+
+  async onEmail(email: AgentEmail) {
+    console.log("From:", email.from);
+    console.log("To:", email.to);
+    console.log("Subject:", email.headers.get("subject"));
+
+    // Get raw email content
+    const raw = await email.getRaw();
+
+    // Parse with postal-mime
+    const parsed = await PostalMime.parse(raw);
+
+    // Update state
+    this.setState({
+      emails: [...this.state.emails, {
+        from: email.from,
+        subject: parsed.subject ?? "",
+        text: parsed.text ?? "",
+        timestamp: new Date()
+      }]
+    });
+
+    // Reply
+    await this.replyToEmail(email, {
+      fromName: "My Agent",
+      subject: `Re: ${email.headers.get("subject")}`,
+      body: "Thanks for your email! I'll process it shortly.",
+      contentType: "text/plain"
+    });
+  }
+}
+```
+
+**Install postal-mime for parsing:**
+```bash
+npm install postal-mime
+```
+
+## Route Emails to Agent
+
+```typescript
+import { routeAgentRequest, routeAgentEmail, createAddressBasedEmailResolver } from "agents";
+
+export default {
+  async email(message, env) {
+    await routeAgentEmail(message, env, {
+      resolver: createAddressBasedEmailResolver("EmailAgent")
+    });
+  },
+
+  async fetch(request, env) {
+    return routeAgentRequest(request, env) ?? new Response("Not found", { status: 404 });
+  }
+};
+```
+
+## Custom Email Resolvers
+
+### Header-Based Resolver
+
+Routes based on X-Agent headers in replies:
+
+```typescript
+import { createHeaderBasedEmailResolver } from "agents";
+
+await routeAgentEmail(message, env, {
+  resolver: createHeaderBasedEmailResolver()
+});
+```
+
+### Custom Resolver
+
+```typescript
+const customResolver = async (email, env) => {
+  // Parse recipient to determine agent
+  const [localPart] = email.to.split("@");
+  
+  if (localPart.startsWith("support-")) {
+    return {
+      agentName: "SupportAgent",
+      agentId: localPart.replace("support-", "")
+    };
+  }
+  
+  return null; // Don't route
+};
+
+await routeAgentEmail(message, env, { resolver: customResolver });
+```

--- a/agents-sdk/references/mcp.md
+++ b/agents-sdk/references/mcp.md
@@ -1,0 +1,153 @@
+# MCP Server Integration
+
+Agents include a multi-server MCP client for connecting to external MCP servers.
+
+## Add an MCP Server
+
+```typescript
+import { Agent, callable } from "agents";
+
+export class MyAgent extends Agent<Env, State> {
+  @callable()
+  async addServer(name: string, url: string) {
+    const result = await this.addMcpServer(
+      name,
+      url,
+      "https://my-worker.workers.dev",  // callback host for OAuth
+      "agents"                            // routing prefix
+    );
+
+    if (result.state === "authenticating") {
+      // OAuth required - redirect user to result.authUrl
+      return { needsAuth: true, authUrl: result.authUrl };
+    }
+
+    return { ready: true, id: result.id };
+  }
+}
+```
+
+## Use MCP Tools
+
+```typescript
+async onChatMessage() {
+  // Get AI-compatible tools from all connected MCP servers
+  const mcpTools = this.mcp.getAITools();
+  
+  const allTools = {
+    ...localTools,
+    ...mcpTools
+  };
+
+  const result = streamText({
+    model: openai("gpt-4o"),
+    messages: await convertToModelMessages(this.messages),
+    tools: allTools
+  });
+  
+  return result.toUIMessageStreamResponse();
+}
+```
+
+## List MCP Resources
+
+```typescript
+// List all registered servers
+const servers = this.mcp.listServers();
+
+// List tools from all servers
+const tools = this.mcp.listTools();
+
+// List resources
+const resources = this.mcp.listResources();
+
+// List prompts
+const prompts = this.mcp.listPrompts();
+```
+
+## Remove Server
+
+```typescript
+await this.removeMcpServer(serverId);
+```
+
+## Building an MCP Server
+
+Use `McpAgent` from the SDK to create an MCP server.
+
+**Install dependencies:**
+```bash
+npm install @modelcontextprotocol/sdk zod
+```
+
+**Wrangler config:**
+```jsonc
+{
+  "durable_objects": {
+    "bindings": [{ "name": "MyMCP", "class_name": "MyMCP" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["MyMCP"] }]
+}
+```
+
+**Server implementation:**
+```typescript
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpAgent } from "agents/mcp";
+import { z } from "zod";
+
+type State = { counter: number };
+
+export class MyMCP extends McpAgent<Env, State, {}> {
+  server = new McpServer({
+    name: "MyMCPServer",
+    version: "1.0.0"
+  });
+
+  initialState = { counter: 0 };
+
+  async init() {
+    // Register a resource
+    this.server.resource("counter", "mcp://resource/counter", (uri) => ({
+      contents: [{ text: String(this.state.counter), uri: uri.href }]
+    }));
+
+    // Register a tool
+    this.server.registerTool(
+      "increment",
+      {
+        description: "Increment the counter",
+        inputSchema: { amount: z.number().default(1) }
+      },
+      async ({ amount }) => {
+        this.setState({ counter: this.state.counter + amount });
+        return {
+          content: [{ text: `Counter: ${this.state.counter}`, type: "text" }]
+        };
+      }
+    );
+  }
+}
+```
+
+## Serve MCP Server
+
+```typescript
+export default {
+  fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const url = new URL(request.url);
+
+    // SSE transport (legacy)
+    if (url.pathname.startsWith("/sse")) {
+      return MyMCP.serveSSE("/sse", { binding: "MyMCP" }).fetch(request, env, ctx);
+    }
+
+    // Streamable HTTP transport (recommended)
+    if (url.pathname.startsWith("/mcp")) {
+      return MyMCP.serve("/mcp", { binding: "MyMCP" }).fetch(request, env, ctx);
+    }
+
+    return new Response("Not found", { status: 404 });
+  }
+};
+```

--- a/agents-sdk/references/state-scheduling.md
+++ b/agents-sdk/references/state-scheduling.md
@@ -1,0 +1,208 @@
+# State, Scheduling & Queues
+
+## State Management
+
+State persists automatically to SQLite and broadcasts to connected clients.
+
+### Define Typed State
+
+```typescript
+type State = { 
+  count: number;
+  items: string[];
+  lastUpdated: Date;
+};
+
+export class MyAgent extends Agent<Env, State> {
+  initialState: State = { 
+    count: 0, 
+    items: [],
+    lastUpdated: new Date()
+  };
+}
+```
+
+### Read and Update State
+
+```typescript
+// Read (lazy-loaded from SQLite on first access)
+const count = this.state.count;
+
+// Update (persists to SQLite, broadcasts to clients)
+this.setState({ 
+  ...this.state, 
+  count: this.state.count + 1 
+});
+```
+
+### React to State Changes
+
+```typescript
+onStateUpdate(state: State, source: Connection | "server") {
+  if (source !== "server") {
+    // Client updated state via WebSocket
+    console.log("Client update:", state);
+  }
+}
+```
+
+### Client-Side State Sync (React)
+
+```tsx
+import { useAgent } from "agents/react";
+import { useState } from "react";
+
+function App() {
+  const [state, setLocalState] = useState<State>({ count: 0 });
+  
+  const agent = useAgent<State>({
+    agent: "MyAgent",
+    name: "instance-1",
+    onStateUpdate: (newState) => setLocalState(newState)
+  });
+
+  const increment = () => {
+    agent.setState({ ...state, count: state.count + 1 });
+  };
+
+  return <button onClick={increment}>Count: {state.count}</button>;
+}
+```
+
+The `onStateUpdate` callback receives state changes from the server. Use local React state to store and render the synced state.
+
+## Scheduling
+
+Schedule methods to run at specific times using `this.schedule()`.
+
+### Schedule Types
+
+```typescript
+// At specific Date
+await this.schedule(new Date("2025-12-25T00:00:00Z"), "sendGreeting", { to: "user" });
+
+// Delay in seconds
+await this.schedule(60, "checkStatus", { id: "abc123" }); // 1 minute
+
+// Cron expression (recurring)
+await this.schedule("0 * * * *", "hourlyCleanup", {}); // Every hour
+await this.schedule("0 9 * * 1-5", "weekdayReport", {}); // 9am weekdays
+```
+
+### Schedule Handler
+
+```typescript
+export class MyAgent extends Agent<Env, State> {
+  async sendGreeting(payload: { to: string }, schedule: Schedule) {
+    console.log(`Sending greeting to ${payload.to}`);
+    // Cron schedules automatically reschedule; one-time schedules are deleted
+  }
+}
+```
+
+### Manage Schedules
+
+```typescript
+// Get all schedules
+const schedules = this.getSchedules();
+
+// Get by type
+const crons = this.getSchedules({ type: "cron" });
+
+// Get by time range
+const upcoming = this.getSchedules({ 
+  timeRange: { start: new Date(), end: nextWeek } 
+});
+
+// Cancel
+await this.cancelSchedule(schedule.id);
+```
+
+## Task Queue
+
+Process tasks sequentially with automatic dequeue on success.
+
+### Queue a Task
+
+```typescript
+await this.queue("processItem", { itemId: "123", priority: "high" });
+```
+
+### Queue Handler
+
+```typescript
+async processItem(payload: { itemId: string }, queueItem: QueueItem) {
+  const item = await fetchItem(payload.itemId);
+  await processItem(item);
+  // Task automatically dequeued on success
+}
+```
+
+### Queue Operations
+
+```typescript
+// Manual dequeue
+await this.dequeue(queueItem.id);
+
+// Dequeue all
+await this.dequeueAll();
+
+// Dequeue by callback
+await this.dequeueAllByCallback("processItem");
+
+// Query queue
+const pending = await this.getQueues("priority", "high");
+```
+
+## SQL API
+
+Direct SQLite access for custom queries:
+
+```typescript
+// Create table
+this.sql`
+  CREATE TABLE IF NOT EXISTS items (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    created_at INTEGER DEFAULT (unixepoch())
+  )
+`;
+
+// Insert with params
+this.sql`INSERT INTO items (id, name) VALUES (${id}, ${name})`;
+
+// Query with types
+const items = this.sql<{ id: string; name: string }>`
+  SELECT * FROM items WHERE name LIKE ${`%${search}%`}
+`;
+```
+
+## Lifecycle Callbacks
+
+```typescript
+export class MyAgent extends Agent<Env, State> {
+  // Called when agent starts (after hibernation or first create)
+  async onStart() {
+    console.log("Agent started:", this.name);
+  }
+
+  // WebSocket connected
+  onConnect(conn: Connection, ctx: ConnectionContext) {
+    console.log("Client connected:", conn.id);
+  }
+
+  // WebSocket message (non-RPC)
+  onMessage(conn: Connection, message: WSMessage) {
+    console.log("Received:", message);
+  }
+
+  // State changed
+  onStateUpdate(state: State, source: Connection | "server") {}
+
+  // Error handler
+  onError(error: unknown) {
+    console.error("Agent error:", error);
+    throw error; // Re-throw to propagate
+  }
+}
+```

--- a/agents-sdk/references/streaming-chat.md
+++ b/agents-sdk/references/streaming-chat.md
@@ -1,0 +1,176 @@
+# Streaming Chat with AIChatAgent
+
+`AIChatAgent` provides streaming chat with automatic message persistence and resumable streams.
+
+## Basic Chat Agent
+
+```typescript
+import { AIChatAgent } from "@cloudflare/ai-chat";
+import { streamText, convertToModelMessages } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+export class Chat extends AIChatAgent<Env> {
+  async onChatMessage(onFinish) {
+    const result = streamText({
+      model: openai("gpt-4o"),
+      messages: await convertToModelMessages(this.messages),
+      onFinish
+    });
+    return result.toUIMessageStreamResponse();
+  }
+}
+```
+
+## With Custom System Prompt
+
+```typescript
+export class Chat extends AIChatAgent<Env> {
+  async onChatMessage(onFinish) {
+    const result = streamText({
+      model: openai("gpt-4o"),
+      system: "You are a helpful assistant specializing in...",
+      messages: await convertToModelMessages(this.messages),
+      onFinish
+    });
+    return result.toUIMessageStreamResponse();
+  }
+}
+```
+
+## With Tools
+
+```typescript
+import { tool } from "ai";
+import { z } from "zod";
+
+const tools = {
+  getWeather: tool({
+    description: "Get weather for a location",
+    parameters: z.object({ location: z.string() }),
+    execute: async ({ location }) => `Weather in ${location}: 72°F, sunny`
+  })
+};
+
+export class Chat extends AIChatAgent<Env> {
+  async onChatMessage(onFinish) {
+    const result = streamText({
+      model: openai("gpt-4o"),
+      messages: await convertToModelMessages(this.messages),
+      tools,
+      onFinish
+    });
+    return result.toUIMessageStreamResponse();
+  }
+}
+```
+
+## Custom UI Message Stream
+
+For more control, use `createUIMessageStream`:
+
+```typescript
+import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
+
+export class Chat extends AIChatAgent<Env> {
+  async onChatMessage(onFinish) {
+    const stream = createUIMessageStream({
+      execute: async ({ writer }) => {
+        const result = streamText({
+          model: openai("gpt-4o"),
+          messages: await convertToModelMessages(this.messages),
+          onFinish
+        });
+        writer.merge(result.toUIMessageStream());
+      }
+    });
+    return createUIMessageStreamResponse({ stream });
+  }
+}
+```
+
+## Resumable Streaming
+
+Streams automatically resume if client disconnects and reconnects:
+
+1. Chunks buffered to SQLite during streaming
+2. On reconnect, buffered chunks sent immediately
+3. Live streaming continues from where it left off
+
+**Enabled by default.** To disable:
+
+```tsx
+const { messages } = useAgentChat({ agent, resume: false });
+```
+
+## React Client
+
+```tsx
+import { useAgent } from "agents/react";
+import { useAgentChat } from "@cloudflare/ai-chat/react";
+
+function ChatUI() {
+  const agent = useAgent({
+    agent: "Chat",
+    name: "my-chat-session"
+  });
+
+  const { 
+    messages, 
+    input, 
+    handleInputChange, 
+    handleSubmit, 
+    status 
+  } = useAgentChat({ agent });
+
+  return (
+    <div>
+      {messages.map((m) => (
+        <div key={m.id}>
+          <strong>{m.role}:</strong> {m.content}
+        </div>
+      ))}
+      
+      <form onSubmit={handleSubmit}>
+        <input 
+          value={input} 
+          onChange={handleInputChange}
+          disabled={status === "streaming"}
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+}
+```
+
+## Streaming RPC Methods
+
+For non-chat streaming, use `@callable({ streaming: true })`:
+
+```typescript
+import { Agent, callable, StreamingResponse } from "agents";
+
+export class MyAgent extends Agent<Env> {
+  @callable({ streaming: true })
+  async streamData(stream: StreamingResponse, query: string) {
+    for (let i = 0; i < 10; i++) {
+      stream.send(`Result ${i}: ${query}`);
+      await sleep(100);
+    }
+    stream.close();
+  }
+}
+```
+
+Client receives streamed messages via WebSocket RPC.
+
+## Status Values
+
+`useAgentChat` status:
+
+| Status | Meaning |
+|--------|---------|
+| `ready` | Idle, ready for input |
+| `streaming` | Response streaming |
+| `submitted` | Request sent, waiting |
+| `error` | Error occurred |

--- a/durable-objects/SKILL.md
+++ b/durable-objects/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: durable-objects
+description: Create and review Cloudflare Durable Objects. Use when building stateful coordination (chat rooms, multiplayer games, booking systems), implementing RPC methods, SQLite storage, alarms, WebSockets, or reviewing DO code for best practices. Covers Workers integration, wrangler config, and testing with Vitest.
+---
+
+# Durable Objects
+
+Build stateful, coordinated applications on Cloudflare's edge using Durable Objects.
+
+## When to Use
+
+- Creating new Durable Object classes for stateful coordination
+- Implementing RPC methods, alarms, or WebSocket handlers
+- Reviewing existing DO code for best practices
+- Configuring wrangler.jsonc/toml for DO bindings and migrations
+- Writing tests with `@cloudflare/vitest-pool-workers`
+- Designing sharding strategies and parent-child relationships
+
+## Reference Documentation
+
+- `./references/rules.md` - Core rules, storage, concurrency, RPC, alarms
+- `./references/testing.md` - Vitest setup, unit/integration tests, alarm testing
+- `./references/workers.md` - Workers handlers, types, wrangler config, observability
+
+Search: `blockConcurrencyWhile`, `idFromName`, `getByName`, `setAlarm`, `sql.exec`
+
+## Core Principles
+
+### Use Durable Objects For
+
+| Need | Example |
+|------|---------|
+| Coordination | Chat rooms, multiplayer games, collaborative docs |
+| Strong consistency | Inventory, booking systems, turn-based games |
+| Per-entity storage | Multi-tenant SaaS, per-user data |
+| Persistent connections | WebSockets, real-time notifications |
+| Scheduled work per entity | Subscription renewals, game timeouts |
+
+### Do NOT Use For
+
+- Stateless request handling (use plain Workers)
+- Maximum global distribution needs
+- High fan-out independent requests
+
+## Quick Reference
+
+### Wrangler Configuration
+
+```jsonc
+// wrangler.jsonc
+{
+  "durable_objects": {
+    "bindings": [{ "name": "MY_DO", "class_name": "MyDurableObject" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["MyDurableObject"] }]
+}
+```
+
+### Basic Durable Object Pattern
+
+```typescript
+import { DurableObject } from "cloudflare:workers";
+
+export interface Env {
+  MY_DO: DurableObjectNamespace<MyDurableObject>;
+}
+
+export class MyDurableObject extends DurableObject<Env> {
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    ctx.blockConcurrencyWhile(async () => {
+      this.ctx.storage.sql.exec(`
+        CREATE TABLE IF NOT EXISTS items (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          data TEXT NOT NULL
+        )
+      `);
+    });
+  }
+
+  async addItem(data: string): Promise<number> {
+    const result = this.ctx.storage.sql.exec<{ id: number }>(
+      "INSERT INTO items (data) VALUES (?) RETURNING id",
+      data
+    );
+    return result.one().id;
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const stub = env.MY_DO.getByName("my-instance");
+    const id = await stub.addItem("hello");
+    return Response.json({ id });
+  },
+};
+```
+
+## Critical Rules
+
+1. **Model around coordination atoms** - One DO per chat room/game/user, not one global DO
+2. **Use `getByName()` for deterministic routing** - Same input = same DO instance
+3. **Use SQLite storage** - Configure `new_sqlite_classes` in migrations
+4. **Initialize in constructor** - Use `blockConcurrencyWhile()` for schema setup only
+5. **Use RPC methods** - Not fetch() handler (compatibility date >= 2024-04-03)
+6. **Persist first, cache second** - Always write to storage before updating in-memory state
+7. **One alarm per DO** - `setAlarm()` replaces any existing alarm
+
+## Anti-Patterns (NEVER)
+
+- Single global DO handling all requests (bottleneck)
+- Using `blockConcurrencyWhile()` on every request (kills throughput)
+- Storing critical state only in memory (lost on eviction/crash)
+- Using `await` between related storage writes (breaks atomicity)
+- Holding `blockConcurrencyWhile()` across `fetch()` or external I/O
+
+## Stub Creation
+
+```typescript
+// Deterministic - preferred for most cases
+const stub = env.MY_DO.getByName("room-123");
+
+// From existing ID string
+const id = env.MY_DO.idFromString(storedIdString);
+const stub = env.MY_DO.get(id);
+
+// New unique ID - store mapping externally
+const id = env.MY_DO.newUniqueId();
+const stub = env.MY_DO.get(id);
+```
+
+## Storage Operations
+
+```typescript
+// SQL (synchronous, recommended)
+this.ctx.storage.sql.exec("INSERT INTO t (c) VALUES (?)", value);
+const rows = this.ctx.storage.sql.exec<Row>("SELECT * FROM t").toArray();
+
+// KV (async)
+await this.ctx.storage.put("key", value);
+const val = await this.ctx.storage.get<Type>("key");
+```
+
+## Alarms
+
+```typescript
+// Schedule (replaces existing)
+await this.ctx.storage.setAlarm(Date.now() + 60_000);
+
+// Handler
+async alarm(): Promise<void> {
+  // Process scheduled work
+  // Optionally reschedule: await this.ctx.storage.setAlarm(...)
+}
+
+// Cancel
+await this.ctx.storage.deleteAlarm();
+```
+
+## Testing Quick Start
+
+```typescript
+import { env } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+
+describe("MyDO", () => {
+  it("should work", async () => {
+    const stub = env.MY_DO.getByName("test");
+    const result = await stub.addItem("test");
+    expect(result).toBe(1);
+  });
+});
+```

--- a/durable-objects/references/rules.md
+++ b/durable-objects/references/rules.md
@@ -1,0 +1,286 @@
+# Durable Objects Rules & Best Practices
+
+## Design & Sharding
+
+### Model Around Coordination Atoms
+
+Create one DO per logical unit needing coordination: chat room, game session, document, user, tenant.
+
+```typescript
+// ✅ Good: One DO per chat room
+const stub = env.CHAT_ROOM.getByName(roomId);
+
+// ❌ Bad: Single global DO
+const stub = env.CHAT_ROOM.getByName("global"); // Bottleneck!
+```
+
+### Parent-Child Relationships
+
+For hierarchical data, create separate child DOs. Parent tracks references, children handle own state.
+
+```typescript
+// Parent: GameServer tracks match references
+// Children: GameMatch handles individual match state
+async createMatch(name: string): Promise<string> {
+  const matchId = crypto.randomUUID();
+  this.ctx.storage.sql.exec(
+    "INSERT INTO matches (id, name) VALUES (?, ?)",
+    matchId, name
+  );
+  const child = this.env.GAME_MATCH.getByName(matchId);
+  await child.init(matchId, name);
+  return matchId;
+}
+```
+
+### Location Hints
+
+Influence DO creation location for latency-sensitive apps:
+
+```typescript
+const id = env.GAME.idFromName(gameId, { locationHint: "wnam" });
+```
+
+Available hints: `wnam`, `enam`, `sam`, `weur`, `eeur`, `apac`, `oc`, `afr`, `me`.
+
+## Storage
+
+### SQLite (Recommended)
+
+Configure in wrangler:
+```jsonc
+{ "migrations": [{ "tag": "v1", "new_sqlite_classes": ["MyDO"] }] }
+```
+
+SQL API is synchronous:
+```typescript
+// Write
+this.ctx.storage.sql.exec(
+  "INSERT INTO items (name, value) VALUES (?, ?)",
+  name, value
+);
+
+// Read
+const rows = this.ctx.storage.sql.exec<{ id: number; name: string }>(
+  "SELECT * FROM items WHERE name = ?", name
+).toArray();
+
+// Single row
+const row = this.ctx.storage.sql.exec<{ count: number }>(
+  "SELECT COUNT(*) as count FROM items"
+).one();
+```
+
+### Migrations
+
+Use `PRAGMA user_version` for schema versioning:
+
+```typescript
+constructor(ctx: DurableObjectState, env: Env) {
+  super(ctx, env);
+  ctx.blockConcurrencyWhile(async () => this.migrate());
+}
+
+private async migrate() {
+  const version = this.ctx.storage.sql
+    .exec<{ user_version: number }>("PRAGMA user_version")
+    .one().user_version;
+
+  if (version < 1) {
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS items (id INTEGER PRIMARY KEY, data TEXT);
+      CREATE INDEX IF NOT EXISTS idx_items_data ON items(data);
+      PRAGMA user_version = 1;
+    `);
+  }
+  if (version < 2) {
+    this.ctx.storage.sql.exec(`
+      ALTER TABLE items ADD COLUMN created_at INTEGER;
+      PRAGMA user_version = 2;
+    `);
+  }
+}
+```
+
+### State Types
+
+| Type | Speed | Persistence | Use Case |
+|------|-------|-------------|----------|
+| Class properties | Fastest | Lost on eviction | Caching, active connections |
+| SQLite storage | Fast | Durable | Primary data |
+| External (R2, D1) | Variable | Durable, cross-DO | Large files, shared data |
+
+**Rule**: Always persist critical state to SQLite first, then update in-memory cache.
+
+## Concurrency
+
+### Input/Output Gates
+
+Storage operations automatically block other requests (input gates). Responses wait for writes (output gates).
+
+```typescript
+async increment(): Promise<number> {
+  // Safe: input gates block interleaving during storage ops
+  const val = (await this.ctx.storage.get<number>("count")) ?? 0;
+  await this.ctx.storage.put("count", val + 1);
+  return val + 1;
+}
+```
+
+### Write Coalescing
+
+Multiple writes without `await` between them are batched atomically:
+
+```typescript
+// ✅ Good: All three writes commit atomically
+this.ctx.storage.sql.exec("UPDATE accounts SET balance = balance - ? WHERE id = ?", amount, fromId);
+this.ctx.storage.sql.exec("UPDATE accounts SET balance = balance + ? WHERE id = ?", amount, toId);
+this.ctx.storage.sql.exec("INSERT INTO transfers (from_id, to_id, amount) VALUES (?, ?, ?)", fromId, toId, amount);
+
+// ❌ Bad: await breaks coalescing
+await this.ctx.storage.put("key1", val1);
+await this.ctx.storage.put("key2", val2); // Separate transaction!
+```
+
+### Race Conditions with External I/O
+
+`fetch()` and other non-storage I/O allows interleaving:
+
+```typescript
+// ⚠️ Race condition possible
+async processItem(id: string) {
+  const item = await this.ctx.storage.get<Item>(`item:${id}`);
+  if (item?.status === "pending") {
+    await fetch("https://api.example.com/process"); // Other requests can run here!
+    await this.ctx.storage.put(`item:${id}`, { status: "completed" });
+  }
+}
+```
+
+**Solution**: Use optimistic locking (version numbers) or `transaction()`.
+
+### blockConcurrencyWhile()
+
+Blocks ALL concurrency. Use sparingly - only for initialization:
+
+```typescript
+// ✅ Good: One-time init
+constructor(ctx: DurableObjectState, env: Env) {
+  super(ctx, env);
+  ctx.blockConcurrencyWhile(async () => this.migrate());
+}
+
+// ❌ Bad: On every request (kills throughput)
+async handleRequest() {
+  await this.ctx.blockConcurrencyWhile(async () => {
+    // ~5ms = max 200 req/sec
+  });
+}
+```
+
+**Never** hold across external I/O (fetch, R2, KV).
+
+## RPC Methods
+
+Use RPC (compatibility date >= 2024-04-03) instead of fetch() handler:
+
+```typescript
+export class ChatRoom extends DurableObject<Env> {
+  async sendMessage(userId: string, content: string): Promise<Message> {
+    // Public methods are RPC endpoints
+    const result = this.ctx.storage.sql.exec<{ id: number }>(
+      "INSERT INTO messages (user_id, content) VALUES (?, ?) RETURNING id",
+      userId, content
+    );
+    return { id: result.one().id, userId, content };
+  }
+}
+
+// Caller
+const stub = env.CHAT_ROOM.getByName(roomId);
+const msg = await stub.sendMessage("user-123", "Hello!"); // Typed!
+```
+
+### Explicit init() Method
+
+DOs don't know their own ID. Pass identity explicitly:
+
+```typescript
+async init(entityId: string, metadata: Metadata): Promise<void> {
+  await this.ctx.storage.put("entityId", entityId);
+  await this.ctx.storage.put("metadata", metadata);
+}
+```
+
+## Alarms
+
+One alarm per DO. `setAlarm()` replaces existing.
+
+```typescript
+// Schedule
+await this.ctx.storage.setAlarm(Date.now() + 60_000);
+
+// Handler
+async alarm(): Promise<void> {
+  const tasks = this.ctx.storage.sql.exec<Task>(
+    "SELECT * FROM tasks WHERE due_at <= ?", Date.now()
+  ).toArray();
+  
+  for (const task of tasks) {
+    await this.processTask(task);
+  }
+  
+  // Reschedule if more work
+  const next = this.ctx.storage.sql.exec<{ due_at: number }>(
+    "SELECT MIN(due_at) as due_at FROM tasks WHERE due_at > ?", Date.now()
+  ).one();
+  if (next?.due_at) {
+    await this.ctx.storage.setAlarm(next.due_at);
+  }
+}
+
+// Get/Delete
+const alarm = await this.ctx.storage.getAlarm();
+await this.ctx.storage.deleteAlarm();
+```
+
+**Retry**: Alarms auto-retry on failure. Use idempotent handlers.
+
+## WebSockets (Hibernation API)
+
+```typescript
+async fetch(request: Request): Promise<Response> {
+  const pair = new WebSocketPair();
+  this.ctx.acceptWebSocket(pair[1]);
+  return new Response(null, { status: 101, webSocket: pair[0] });
+}
+
+async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer) {
+  const data = JSON.parse(message as string);
+  // Handle message
+  ws.send(JSON.stringify({ type: "ack" }));
+}
+
+async webSocketClose(ws: WebSocket, code: number, reason: string) {
+  // Cleanup
+}
+
+// Broadcast
+getWebSockets().forEach(ws => ws.send(JSON.stringify(payload)));
+```
+
+## Error Handling
+
+```typescript
+async safeOperation(): Promise<Result> {
+  try {
+    return await this.riskyOperation();
+  } catch (error) {
+    console.error("Operation failed:", error);
+    // Log to external service if needed
+    throw error; // Re-throw to signal failure to caller
+  }
+}
+```
+
+**Note**: Uncaught exceptions may terminate the DO instance. In-memory state is lost, but SQLite storage persists.

--- a/durable-objects/references/testing.md
+++ b/durable-objects/references/testing.md
@@ -1,0 +1,264 @@
+# Testing Durable Objects
+
+Use `@cloudflare/vitest-pool-workers` to test DOs inside the Workers runtime.
+
+## Setup
+
+### Install Dependencies
+
+```bash
+npm i -D vitest@~3.2.0 @cloudflare/vitest-pool-workers
+```
+
+### vitest.config.ts
+
+```typescript
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.toml" },
+      },
+    },
+  },
+});
+```
+
+### TypeScript Config (test/tsconfig.json)
+
+```jsonc
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/vitest-pool-workers"]
+  },
+  "include": ["./**/*.ts", "../src/worker-configuration.d.ts"]
+}
+```
+
+### Environment Types (env.d.ts)
+
+```typescript
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}
+```
+
+## Unit Tests (Direct DO Access)
+
+```typescript
+import { env } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+
+describe("Counter DO", () => {
+  it("should increment", async () => {
+    const stub = env.COUNTER.getByName("test-counter");
+    
+    expect(await stub.increment()).toBe(1);
+    expect(await stub.increment()).toBe(2);
+    expect(await stub.getCount()).toBe(2);
+  });
+
+  it("isolates different instances", async () => {
+    const stub1 = env.COUNTER.getByName("counter-1");
+    const stub2 = env.COUNTER.getByName("counter-2");
+    
+    await stub1.increment();
+    await stub1.increment();
+    await stub2.increment();
+    
+    expect(await stub1.getCount()).toBe(2);
+    expect(await stub2.getCount()).toBe(1);
+  });
+});
+```
+
+## Integration Tests (HTTP via SELF)
+
+```typescript
+import { SELF } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+
+describe("Worker HTTP", () => {
+  it("should increment via POST", async () => {
+    const res = await SELF.fetch("http://example.com?id=test", {
+      method: "POST",
+    });
+    
+    expect(res.status).toBe(200);
+    const data = await res.json<{ count: number }>();
+    expect(data.count).toBe(1);
+  });
+
+  it("should get count via GET", async () => {
+    await SELF.fetch("http://example.com?id=get-test", { method: "POST" });
+    await SELF.fetch("http://example.com?id=get-test", { method: "POST" });
+    
+    const res = await SELF.fetch("http://example.com?id=get-test");
+    const data = await res.json<{ count: number }>();
+    expect(data.count).toBe(2);
+  });
+});
+```
+
+## Direct Internal Access
+
+Use `runInDurableObject()` to access instance internals and storage:
+
+```typescript
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import { Counter } from "../src";
+
+describe("DO internals", () => {
+  it("can verify storage directly", async () => {
+    const stub = env.COUNTER.getByName("direct-test");
+    await stub.increment();
+    await stub.increment();
+
+    await runInDurableObject(stub, async (instance: Counter, state) => {
+      expect(instance).toBeInstanceOf(Counter);
+      
+      const result = state.storage.sql
+        .exec<{ value: number }>(
+          "SELECT value FROM counters WHERE name = ?",
+          "default"
+        )
+        .one();
+      expect(result.value).toBe(2);
+    });
+  });
+});
+```
+
+## List DO IDs
+
+```typescript
+import { env, listDurableObjectIds } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+
+describe("DO listing", () => {
+  it("can list all IDs in namespace", async () => {
+    const id1 = env.COUNTER.idFromName("list-1");
+    const id2 = env.COUNTER.idFromName("list-2");
+    
+    await env.COUNTER.get(id1).increment();
+    await env.COUNTER.get(id2).increment();
+    
+    const ids = await listDurableObjectIds(env.COUNTER);
+    expect(ids.length).toBe(2);
+    expect(ids.some(id => id.equals(id1))).toBe(true);
+    expect(ids.some(id => id.equals(id2))).toBe(true);
+  });
+});
+```
+
+## Testing Alarms
+
+Use `runDurableObjectAlarm()` to trigger alarms immediately:
+
+```typescript
+import { env, runInDurableObject, runDurableObjectAlarm } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+
+describe("DO alarms", () => {
+  it("can trigger alarms immediately", async () => {
+    const stub = env.COUNTER.getByName("alarm-test");
+    await stub.increment();
+    await stub.increment();
+    expect(await stub.getCount()).toBe(2);
+
+    // Schedule alarm
+    await runInDurableObject(stub, async (instance, state) => {
+      await state.storage.setAlarm(Date.now() + 60_000);
+    });
+
+    // Execute immediately without waiting
+    const ran = await runDurableObjectAlarm(stub);
+    expect(ran).toBe(true);
+
+    // Verify alarm handler ran (if it resets counter)
+    expect(await stub.getCount()).toBe(0);
+
+    // No alarm scheduled now
+    const ranAgain = await runDurableObjectAlarm(stub);
+    expect(ranAgain).toBe(false);
+  });
+});
+```
+
+Example alarm handler:
+```typescript
+async alarm(): Promise<void> {
+  this.ctx.storage.sql.exec("DELETE FROM counters");
+}
+```
+
+## Test Isolation
+
+Each test gets isolated storage automatically. DOs from one test don't affect others:
+
+```typescript
+describe("Isolation", () => {
+  it("first test creates DO", async () => {
+    const stub = env.COUNTER.getByName("isolated");
+    await stub.increment();
+    expect(await stub.getCount()).toBe(1);
+  });
+
+  it("second test has fresh state", async () => {
+    const ids = await listDurableObjectIds(env.COUNTER);
+    expect(ids.length).toBe(0); // Previous test's DO is gone
+    
+    const stub = env.COUNTER.getByName("isolated");
+    expect(await stub.getCount()).toBe(0); // Fresh instance
+  });
+});
+```
+
+## SQLite Storage Testing
+
+```typescript
+describe("SQLite", () => {
+  it("can verify SQL storage", async () => {
+    const stub = env.COUNTER.getByName("sqlite-test");
+    await stub.increment("page-views");
+    await stub.increment("page-views");
+    await stub.increment("api-calls");
+
+    await runInDurableObject(stub, async (instance, state) => {
+      const rows = state.storage.sql
+        .exec<{ name: string; value: number }>(
+          "SELECT name, value FROM counters ORDER BY name"
+        )
+        .toArray();
+
+      expect(rows).toEqual([
+        { name: "api-calls", value: 1 },
+        { name: "page-views", value: 2 },
+      ]);
+
+      expect(state.storage.sql.databaseSize).toBeGreaterThan(0);
+    });
+  });
+});
+```
+
+## Running Tests
+
+```bash
+npx vitest        # Watch mode
+npx vitest run    # Single run
+```
+
+package.json:
+```json
+{
+  "scripts": {
+    "test": "vitest"
+  }
+}
+```

--- a/durable-objects/references/workers.md
+++ b/durable-objects/references/workers.md
@@ -1,0 +1,346 @@
+# Cloudflare Workers Best Practices
+
+High-level guidance for Workers that invoke Durable Objects.
+
+## Wrangler Configuration
+
+### wrangler.jsonc (Recommended)
+
+```jsonc
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2024-12-01",
+  "compatibility_flags": ["nodejs_compat"],
+
+  "durable_objects": {
+    "bindings": [
+      { "name": "CHAT_ROOM", "class_name": "ChatRoom" },
+      { "name": "USER_SESSION", "class_name": "UserSession" }
+    ]
+  },
+
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["ChatRoom", "UserSession"] }
+  ],
+
+  // Environment variables
+  "vars": {
+    "ENVIRONMENT": "production"
+  },
+
+  // KV namespaces
+  "kv_namespaces": [
+    { "binding": "CONFIG", "id": "abc123" }
+  ],
+
+  // R2 buckets
+  "r2_buckets": [
+    { "binding": "UPLOADS", "bucket_name": "my-uploads" }
+  ],
+
+  // D1 databases
+  "d1_databases": [
+    { "binding": "DB", "database_id": "xyz789" }
+  ]
+}
+```
+
+### wrangler.toml (Alternative)
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[durable_objects.bindings]]
+name = "CHAT_ROOM"
+class_name = "ChatRoom"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["ChatRoom"]
+
+[vars]
+ENVIRONMENT = "production"
+```
+
+## TypeScript Types
+
+### Environment Interface
+
+```typescript
+// src/types.ts
+import { ChatRoom } from "./durable-objects/chat-room";
+import { UserSession } from "./durable-objects/user-session";
+
+export interface Env {
+  // Durable Objects
+  CHAT_ROOM: DurableObjectNamespace<ChatRoom>;
+  USER_SESSION: DurableObjectNamespace<UserSession>;
+
+  // KV
+  CONFIG: KVNamespace;
+
+  // R2
+  UPLOADS: R2Bucket;
+
+  // D1
+  DB: D1Database;
+
+  // Environment variables
+  ENVIRONMENT: string;
+  API_KEY: string; // From secrets
+}
+```
+
+### Export Durable Object Classes
+
+```typescript
+// src/index.ts
+export { ChatRoom } from "./durable-objects/chat-room";
+export { UserSession } from "./durable-objects/user-session";
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    // Worker handler
+  },
+};
+```
+
+## Worker Handler Pattern
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+
+    try {
+      // Route to appropriate handler
+      if (url.pathname.startsWith("/api/rooms")) {
+        return handleRooms(request, env);
+      }
+      if (url.pathname.startsWith("/api/users")) {
+        return handleUsers(request, env);
+      }
+
+      return new Response("Not Found", { status: 404 });
+    } catch (error) {
+      console.error("Request failed:", error);
+      return new Response("Internal Server Error", { status: 500 });
+    }
+  },
+};
+
+async function handleRooms(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const roomId = url.searchParams.get("room");
+
+  if (!roomId) {
+    return Response.json({ error: "Missing room parameter" }, { status: 400 });
+  }
+
+  const stub = env.CHAT_ROOM.getByName(roomId);
+
+  if (request.method === "POST") {
+    const body = await request.json<{ userId: string; message: string }>();
+    const result = await stub.sendMessage(body.userId, body.message);
+    return Response.json(result);
+  }
+
+  const messages = await stub.getMessages();
+  return Response.json(messages);
+}
+```
+
+## Request Validation
+
+```typescript
+import { z } from "zod";
+
+const SendMessageSchema = z.object({
+  userId: z.string().min(1),
+  message: z.string().min(1).max(1000),
+});
+
+async function handleSendMessage(request: Request, env: Env): Promise<Response> {
+  const body = await request.json();
+  const result = SendMessageSchema.safeParse(body);
+
+  if (!result.success) {
+    return Response.json(
+      { error: "Validation failed", details: result.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const stub = env.CHAT_ROOM.getByName(result.data.userId);
+  const message = await stub.sendMessage(result.data.userId, result.data.message);
+  return Response.json(message);
+}
+```
+
+## Observability & Logging
+
+### Structured Logging
+
+```typescript
+function log(level: "info" | "warn" | "error", message: string, data?: Record<string, unknown>) {
+  console.log(JSON.stringify({
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    ...data,
+  }));
+}
+
+// Usage
+log("info", "Request received", { path: url.pathname, method: request.method });
+log("error", "DO call failed", { roomId, error: String(error) });
+```
+
+### Request Tracing
+
+```typescript
+async function handleRequest(request: Request, env: Env): Promise<Response> {
+  const requestId = crypto.randomUUID();
+  const startTime = Date.now();
+
+  try {
+    const response = await processRequest(request, env);
+
+    log("info", "Request completed", {
+      requestId,
+      duration: Date.now() - startTime,
+      status: response.status,
+    });
+
+    return response;
+  } catch (error) {
+    log("error", "Request failed", {
+      requestId,
+      duration: Date.now() - startTime,
+      error: String(error),
+    });
+    throw error;
+  }
+}
+```
+
+### Tail Workers (Production)
+
+For production logging, use Tail Workers to forward logs:
+
+```jsonc
+// wrangler.jsonc
+{
+  "tail_consumers": [
+    { "service": "log-collector" }
+  ]
+}
+```
+
+## Error Handling
+
+### Graceful DO Errors
+
+```typescript
+async function callDO(stub: DurableObjectStub<ChatRoom>, method: string): Promise<Response> {
+  try {
+    const result = await stub.getMessages();
+    return Response.json(result);
+  } catch (error) {
+    if (error instanceof Error) {
+      // DO threw an error
+      log("error", "DO operation failed", { error: error.message });
+      return Response.json(
+        { error: "Service temporarily unavailable" },
+        { status: 503 }
+      );
+    }
+    throw error;
+  }
+}
+```
+
+### Timeout Handling
+
+```typescript
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error("Timeout")), ms)
+  );
+  return Promise.race([promise, timeout]);
+}
+
+// Usage
+const result = await withTimeout(stub.processData(data), 5000);
+```
+
+## CORS Handling
+
+```typescript
+function corsHeaders(): HeadersInit {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders() });
+    }
+
+    const response = await handleRequest(request, env);
+    
+    // Add CORS headers to response
+    const newHeaders = new Headers(response.headers);
+    Object.entries(corsHeaders()).forEach(([k, v]) => newHeaders.set(k, v));
+    
+    return new Response(response.body, {
+      status: response.status,
+      headers: newHeaders,
+    });
+  },
+};
+```
+
+## Secrets Management
+
+Set secrets via wrangler CLI (not in config files):
+
+```bash
+wrangler secret put API_KEY
+wrangler secret put DATABASE_URL
+```
+
+Access in code:
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const apiKey = env.API_KEY; // From secret
+    // ...
+  },
+};
+```
+
+## Development Commands
+
+```bash
+# Local development
+wrangler dev
+
+# Deploy
+wrangler deploy
+
+# Tail logs
+wrangler tail
+
+# List DOs
+wrangler d1 execute DB --command "SELECT * FROM _cf_DO"
+```

--- a/web-perf/SKILL.md
+++ b/web-perf/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: web-perf
+description: Analyzes web performance using Chrome DevTools MCP. Measures Core Web Vitals (FCP, LCP, TBT, CLS, Speed Index), identifies render-blocking resources, network dependency chains, layout shifts, caching issues, and accessibility gaps. Use when asked to audit, profile, debug, or optimize page load performance, Lighthouse scores, or site speed.
+---
+
+# Web Performance Audit
+
+Audit web page performance using Chrome DevTools MCP tools. This skill focuses on Core Web Vitals, network optimization, and high-level accessibility gaps.
+
+## FIRST: Verify MCP Tools Available
+
+**Run this before starting.** Try calling `navigate_page` or `performance_start_trace`. If unavailable, STOP—the chrome-devtools MCP server isn't configured.
+
+Ask the user to add this to their MCP config:
+
+```json
+"chrome-devtools": {
+  "type": "local",
+  "command": ["npx", "-y", "chrome-devtools-mcp@latest"]
+}
+```
+
+## Key Guidelines
+
+- **Be assertive**: Verify claims by checking network requests, DOM, or codebase—then state findings definitively.
+- **Verify before recommending**: Confirm something is unused before suggesting removal.
+- **Quantify impact**: Use estimated savings from insights. Don't prioritize changes with 0ms impact.
+- **Skip non-issues**: If render-blocking resources have 0ms estimated impact, note but don't recommend action.
+- **Be specific**: Say "compress hero.png (450KB) to WebP" not "optimize images".
+- **Prioritize ruthlessly**: A site with 200ms LCP and 0 CLS is already excellent—say so.
+
+## Quick Reference
+
+| Task | Tool Call |
+|------|-----------|
+| Load page | `navigate_page(url: "...")` |
+| Start trace | `performance_start_trace(autoStop: true, reload: true)` |
+| Analyze insight | `performance_analyze_insight(insightSetId: "...", insightName: "...")` |
+| List requests | `list_network_requests(resourceTypes: ["Script", "Stylesheet", ...])` |
+| Request details | `get_network_request(reqid: <id>)` |
+| A11y snapshot | `take_snapshot(verbose: true)` |
+
+## Workflow
+
+Copy this checklist to track progress:
+
+```
+Audit Progress:
+- [ ] Phase 1: Performance trace (navigate + record)
+- [ ] Phase 2: Core Web Vitals analysis (includes CLS culprits)
+- [ ] Phase 3: Network analysis
+- [ ] Phase 4: Accessibility snapshot
+- [ ] Phase 5: Codebase analysis (skip if third-party site)
+```
+
+### Phase 1: Performance Trace
+
+1. Navigate to the target URL:
+   ```
+   navigate_page(url: "<target-url>")
+   ```
+
+2. Start a performance trace with reload to capture cold-load metrics:
+   ```
+   performance_start_trace(autoStop: true, reload: true)
+   ```
+
+3. Wait for trace completion, then retrieve results.
+
+**Troubleshooting:**
+- If trace returns empty or fails, verify the page loaded correctly with `navigate_page` first
+- If insight names don't match, inspect the trace response to list available insights
+
+### Phase 2: Core Web Vitals Analysis
+
+Use `performance_analyze_insight` to extract key metrics.
+
+**Note:** Insight names may vary across Chrome DevTools versions. If an insight name doesn't work, check the `insightSetId` from the trace response to discover available insights.
+
+Common insight names:
+
+| Metric | Insight Name | What to Look For |
+|--------|--------------|------------------|
+| LCP | `LCPBreakdown` | Time to largest contentful paint; breakdown of TTFB, resource load, render delay |
+| CLS | `CLSCulprits` | Elements causing layout shifts (images without dimensions, injected content, font swaps) |
+| Render Blocking | `RenderBlocking` | CSS/JS blocking first paint |
+| Document Latency | `DocumentLatency` | Server response time issues |
+| Network Dependencies | `NetworkRequestsDepGraph` | Request chains delaying critical resources |
+
+Example:
+```
+performance_analyze_insight(insightSetId: "<id-from-trace>", insightName: "LCPBreakdown")
+```
+
+**Key thresholds (good/needs-improvement/poor):**
+- TTFB: < 800ms / < 1.8s / > 1.8s
+- FCP: < 1.8s / < 3s / > 3s
+- LCP: < 2.5s / < 4s / > 4s
+- INP: < 200ms / < 500ms / > 500ms
+- TBT: < 200ms / < 600ms / > 600ms
+- CLS: < 0.1 / < 0.25 / > 0.25
+- Speed Index: < 3.4s / < 5.8s / > 5.8s
+
+### Phase 3: Network Analysis
+
+List all network requests to identify optimization opportunities:
+```
+list_network_requests(resourceTypes: ["Script", "Stylesheet", "Document", "Font", "Image"])
+```
+
+**Look for:**
+
+1. **Render-blocking resources**: JS/CSS in `<head>` without `async`/`defer`/`media` attributes
+2. **Network chains**: Resources discovered late because they depend on other resources loading first (e.g., CSS imports, JS-loaded fonts)
+3. **Missing preloads**: Critical resources (fonts, hero images, key scripts) not preloaded
+4. **Caching issues**: Missing or weak `Cache-Control`, `ETag`, or `Last-Modified` headers
+5. **Large payloads**: Uncompressed or oversized JS/CSS bundles
+6. **Unused preconnects**: If flagged, verify by checking if ANY requests went to that origin. If zero requests, it's definitively unused—recommend removal. If requests exist but loaded late, the preconnect may still be valuable.
+
+For detailed request info:
+```
+get_network_request(reqid: <id>)
+```
+
+### Phase 4: Accessibility Snapshot
+
+Take an accessibility tree snapshot:
+```
+take_snapshot(verbose: true)
+```
+
+**Flag high-level gaps:**
+- Missing or duplicate ARIA IDs
+- Elements with poor contrast ratios (check against WCAG AA: 4.5:1 for normal text, 3:1 for large text)
+- Focus traps or missing focus indicators
+- Interactive elements without accessible names
+
+## Phase 5: Codebase Analysis
+
+**Skip if auditing a third-party site without codebase access.**
+
+Analyze the codebase to understand where improvements can be made.
+
+### Detect Framework & Bundler
+
+Search for configuration files to identify the stack:
+
+| Tool | Config Files |
+|------|--------------|
+| Webpack | `webpack.config.js`, `webpack.*.js` |
+| Vite | `vite.config.js`, `vite.config.ts` |
+| Rollup | `rollup.config.js`, `rollup.config.mjs` |
+| esbuild | `esbuild.config.js`, build scripts with `esbuild` |
+| Parcel | `.parcelrc`, `package.json` (parcel field) |
+| Next.js | `next.config.js`, `next.config.mjs` |
+| Nuxt | `nuxt.config.js`, `nuxt.config.ts` |
+| SvelteKit | `svelte.config.js` |
+| Astro | `astro.config.mjs` |
+
+Also check `package.json` for framework dependencies and build scripts.
+
+### Tree-Shaking & Dead Code
+
+- **Webpack**: Check for `mode: 'production'`, `sideEffects` in package.json, `usedExports` optimization
+- **Vite/Rollup**: Tree-shaking enabled by default; check for `treeshake` options
+- **Look for**: Barrel files (`index.js` re-exports), large utility libraries imported wholesale (lodash, moment)
+
+### Unused JS/CSS
+
+- Check for CSS-in-JS vs. static CSS extraction
+- Look for PurgeCSS/UnCSS configuration (Tailwind's `content` config)
+- Identify dynamic imports vs. eager loading
+
+### Polyfills
+
+- Check for `@babel/preset-env` targets and `useBuiltIns` setting
+- Look for `core-js` imports (often oversized)
+- Check `browserslist` config for overly broad targeting
+
+### Compression & Minification
+
+- Check for `terser`, `esbuild`, or `swc` minification
+- Look for gzip/brotli compression in build output or server config
+- Check for source maps in production builds (should be external or disabled)
+
+## Output Format
+
+Present findings as:
+
+1. **Core Web Vitals Summary** - Table with metric, value, and rating (good/needs-improvement/poor)
+2. **Top Issues** - Prioritized list of problems with estimated impact (high/medium/low)
+3. **Recommendations** - Specific, actionable fixes with code snippets or config changes
+4. **Codebase Findings** - Framework/bundler detected, optimization opportunities (omit if no codebase access)

--- a/wrangler/SKILL.md
+++ b/wrangler/SKILL.md
@@ -1,0 +1,887 @@
+---
+name: wrangler
+description: Cloudflare Workers CLI for deploying, developing, and managing Workers, KV, R2, D1, Vectorize, Hyperdrive, Workers AI, Containers, Queues, Workflows, Pipelines, and Secrets Store. Load before running wrangler commands to ensure correct syntax and best practices.
+---
+
+# Wrangler CLI
+
+Deploy, develop, and manage Cloudflare Workers and associated resources.
+
+## FIRST: Verify Wrangler Installation
+
+```bash
+wrangler --version  # Requires v4.x+
+```
+
+If not installed:
+```bash
+npm install -D wrangler@latest
+```
+
+## Key Guidelines
+
+- **Use `wrangler.jsonc`**: Prefer JSON config over TOML. Newer features are JSON-only.
+- **Set `compatibility_date`**: Use a recent date (within 30 days). Check https://developers.cloudflare.com/workers/configuration/compatibility-dates/
+- **Generate types after config changes**: Run `wrangler types` to update TypeScript bindings.
+- **Local dev defaults to local storage**: Bindings use local simulation unless `remote: true`.
+- **Validate config before deploy**: Run `wrangler check` to catch errors early.
+- **Use environments for staging/prod**: Define `env.staging` and `env.production` in config.
+
+## Quick Start: New Worker
+
+```bash
+# Initialize new project
+npx wrangler init my-worker
+
+# Or with a framework
+npx create-cloudflare@latest my-app
+```
+
+## Quick Reference: Core Commands
+
+| Task | Command |
+|------|---------|
+| Start local dev server | `wrangler dev` |
+| Deploy to Cloudflare | `wrangler deploy` |
+| Deploy dry run | `wrangler deploy --dry-run` |
+| Generate TypeScript types | `wrangler types` |
+| Validate configuration | `wrangler check` |
+| View live logs | `wrangler tail` |
+| Delete Worker | `wrangler delete` |
+| Auth status | `wrangler whoami` |
+
+---
+
+## Configuration (wrangler.jsonc)
+
+### Minimal Config
+
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-01-01"
+}
+```
+
+### Full Config with Bindings
+
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-01-01",
+  "compatibility_flags": ["nodejs_compat_v2"],
+
+  // Environment variables
+  "vars": {
+    "ENVIRONMENT": "production"
+  },
+
+  // KV Namespace
+  "kv_namespaces": [
+    { "binding": "KV", "id": "<KV_NAMESPACE_ID>" }
+  ],
+
+  // R2 Bucket
+  "r2_buckets": [
+    { "binding": "BUCKET", "bucket_name": "my-bucket" }
+  ],
+
+  // D1 Database
+  "d1_databases": [
+    { "binding": "DB", "database_name": "my-db", "database_id": "<DB_ID>" }
+  ],
+
+  // Workers AI (always remote)
+  "ai": { "binding": "AI" },
+
+  // Vectorize
+  "vectorize": [
+    { "binding": "VECTOR_INDEX", "index_name": "my-index" }
+  ],
+
+  // Hyperdrive
+  "hyperdrive": [
+    { "binding": "HYPERDRIVE", "id": "<HYPERDRIVE_ID>" }
+  ],
+
+  // Durable Objects
+  "durable_objects": {
+    "bindings": [
+      { "name": "COUNTER", "class_name": "Counter" }
+    ]
+  },
+
+  // Cron triggers
+  "triggers": {
+    "crons": ["0 * * * *"]
+  },
+
+  // Environments
+  "env": {
+    "staging": {
+      "name": "my-worker-staging",
+      "vars": { "ENVIRONMENT": "staging" }
+    }
+  }
+}
+```
+
+### Generate Types from Config
+
+```bash
+# Generate worker-configuration.d.ts
+wrangler types
+
+# Custom output path
+wrangler types ./src/env.d.ts
+
+# Check types are up to date (CI)
+wrangler types --check
+```
+
+---
+
+## Local Development
+
+### Start Dev Server
+
+```bash
+# Local mode (default) - uses local storage simulation
+wrangler dev
+
+# With specific environment
+wrangler dev --env staging
+
+# Force local-only (disable remote bindings)
+wrangler dev --local
+
+# Remote mode - runs on Cloudflare edge (legacy)
+wrangler dev --remote
+
+# Custom port
+wrangler dev --port 8787
+
+# Live reload for HTML changes
+wrangler dev --live-reload
+
+# Test scheduled/cron handlers
+wrangler dev --test-scheduled
+# Then visit: http://localhost:8787/__scheduled
+```
+
+### Remote Bindings for Local Dev
+
+Use `remote: true` in binding config to connect to real resources while running locally:
+
+```jsonc
+{
+  "r2_buckets": [
+    { "binding": "BUCKET", "bucket_name": "my-bucket", "remote": true }
+  ],
+  "ai": { "binding": "AI", "remote": true },
+  "vectorize": [
+    { "binding": "INDEX", "index_name": "my-index", "remote": true }
+  ]
+}
+```
+
+**Recommended remote bindings**: AI (required), Vectorize, Browser Rendering, mTLS, Images.
+
+### Local Secrets
+
+Create `.dev.vars` for local development secrets:
+
+```
+API_KEY=local-dev-key
+DATABASE_URL=postgres://localhost:5432/dev
+```
+
+---
+
+## Deployment
+
+### Deploy Worker
+
+```bash
+# Deploy to production
+wrangler deploy
+
+# Deploy specific environment
+wrangler deploy --env staging
+
+# Dry run (validate without deploying)
+wrangler deploy --dry-run
+
+# Keep dashboard-set variables
+wrangler deploy --keep-vars
+
+# Minify code
+wrangler deploy --minify
+```
+
+### Manage Secrets
+
+```bash
+# Set secret interactively
+wrangler secret put API_KEY
+
+# Set from stdin
+echo "secret-value" | wrangler secret put API_KEY
+
+# List secrets
+wrangler secret list
+
+# Delete secret
+wrangler secret delete API_KEY
+
+# Bulk secrets from JSON file
+wrangler secret bulk secrets.json
+```
+
+### Versions and Rollback
+
+```bash
+# List recent versions
+wrangler versions list
+
+# View specific version
+wrangler versions view <VERSION_ID>
+
+# Rollback to previous version
+wrangler rollback
+
+# Rollback to specific version
+wrangler rollback <VERSION_ID>
+```
+
+---
+
+## KV (Key-Value Store)
+
+### Manage Namespaces
+
+```bash
+# Create namespace
+wrangler kv namespace create MY_KV
+
+# List namespaces
+wrangler kv namespace list
+
+# Delete namespace
+wrangler kv namespace delete --namespace-id <ID>
+```
+
+### Manage Keys
+
+```bash
+# Put value
+wrangler kv key put --namespace-id <ID> "key" "value"
+
+# Put with expiration (seconds)
+wrangler kv key put --namespace-id <ID> "key" "value" --expiration-ttl 3600
+
+# Get value
+wrangler kv key get --namespace-id <ID> "key"
+
+# List keys
+wrangler kv key list --namespace-id <ID>
+
+# Delete key
+wrangler kv key delete --namespace-id <ID> "key"
+
+# Bulk put from JSON
+wrangler kv bulk put --namespace-id <ID> data.json
+```
+
+### Config Binding
+
+```jsonc
+{
+  "kv_namespaces": [
+    { "binding": "CACHE", "id": "<NAMESPACE_ID>" }
+  ]
+}
+```
+
+---
+
+## R2 (Object Storage)
+
+### Manage Buckets
+
+```bash
+# Create bucket
+wrangler r2 bucket create my-bucket
+
+# Create with location hint
+wrangler r2 bucket create my-bucket --location wnam
+
+# List buckets
+wrangler r2 bucket list
+
+# Get bucket info
+wrangler r2 bucket info my-bucket
+
+# Delete bucket
+wrangler r2 bucket delete my-bucket
+```
+
+### Manage Objects
+
+```bash
+# Upload object
+wrangler r2 object put my-bucket/path/file.txt --file ./local-file.txt
+
+# Download object
+wrangler r2 object get my-bucket/path/file.txt
+
+# Delete object
+wrangler r2 object delete my-bucket/path/file.txt
+```
+
+### Config Binding
+
+```jsonc
+{
+  "r2_buckets": [
+    { "binding": "ASSETS", "bucket_name": "my-bucket" }
+  ]
+}
+```
+
+---
+
+## D1 (SQL Database)
+
+### Manage Databases
+
+```bash
+# Create database
+wrangler d1 create my-database
+
+# Create with location
+wrangler d1 create my-database --location wnam
+
+# List databases
+wrangler d1 list
+
+# Get database info
+wrangler d1 info my-database
+
+# Delete database
+wrangler d1 delete my-database
+```
+
+### Execute SQL
+
+```bash
+# Execute SQL command (remote)
+wrangler d1 execute my-database --remote --command "SELECT * FROM users"
+
+# Execute SQL file (remote)
+wrangler d1 execute my-database --remote --file ./schema.sql
+
+# Execute locally
+wrangler d1 execute my-database --local --command "SELECT * FROM users"
+```
+
+### Migrations
+
+```bash
+# Create migration
+wrangler d1 migrations create my-database create_users_table
+
+# List pending migrations
+wrangler d1 migrations list my-database --local
+
+# Apply migrations locally
+wrangler d1 migrations apply my-database --local
+
+# Apply migrations to remote
+wrangler d1 migrations apply my-database --remote
+```
+
+### Export/Backup
+
+```bash
+# Export schema and data
+wrangler d1 export my-database --remote --output backup.sql
+
+# Export schema only
+wrangler d1 export my-database --remote --output schema.sql --no-data
+```
+
+### Config Binding
+
+```jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "my-database",
+      "database_id": "<DATABASE_ID>",
+      "migrations_dir": "./migrations"
+    }
+  ]
+}
+```
+
+---
+
+## Vectorize (Vector Database)
+
+### Manage Indexes
+
+```bash
+# Create index with dimensions
+wrangler vectorize create my-index --dimensions 768 --metric cosine
+
+# Create with preset (auto-configures dimensions/metric)
+wrangler vectorize create my-index --preset @cf/baai/bge-base-en-v1.5
+
+# List indexes
+wrangler vectorize list
+
+# Get index info
+wrangler vectorize get my-index
+
+# Delete index
+wrangler vectorize delete my-index
+```
+
+### Manage Vectors
+
+```bash
+# Insert vectors from NDJSON file
+wrangler vectorize insert my-index --file vectors.ndjson
+
+# Query vectors
+wrangler vectorize query my-index --vector "[0.1, 0.2, ...]" --top-k 10
+```
+
+### Config Binding
+
+```jsonc
+{
+  "vectorize": [
+    { "binding": "SEARCH_INDEX", "index_name": "my-index" }
+  ]
+}
+```
+
+---
+
+## Hyperdrive (Database Accelerator)
+
+### Manage Configs
+
+```bash
+# Create config
+wrangler hyperdrive create my-hyperdrive \
+  --connection-string "postgres://user:pass@host:5432/database"
+
+# List configs
+wrangler hyperdrive list
+
+# Get config details
+wrangler hyperdrive get <HYPERDRIVE_ID>
+
+# Update config
+wrangler hyperdrive update <HYPERDRIVE_ID> --origin-password "new-password"
+
+# Delete config
+wrangler hyperdrive delete <HYPERDRIVE_ID>
+```
+
+### Config Binding
+
+```jsonc
+{
+  "compatibility_flags": ["nodejs_compat_v2"],
+  "hyperdrive": [
+    { "binding": "HYPERDRIVE", "id": "<HYPERDRIVE_ID>" }
+  ]
+}
+```
+
+---
+
+## Workers AI
+
+### List Models
+
+```bash
+# List available models
+wrangler ai models
+
+# List finetunes
+wrangler ai finetune list
+```
+
+### Config Binding
+
+```jsonc
+{
+  "ai": { "binding": "AI" }
+}
+```
+
+**Note**: Workers AI always runs remotely and incurs usage charges even in local dev.
+
+---
+
+## Queues
+
+### Manage Queues
+
+```bash
+# Create queue
+wrangler queues create my-queue
+
+# List queues
+wrangler queues list
+
+# Delete queue
+wrangler queues delete my-queue
+
+# Add consumer to queue
+wrangler queues consumer add my-queue my-worker
+
+# Remove consumer
+wrangler queues consumer remove my-queue my-worker
+```
+
+### Config Binding
+
+```jsonc
+{
+  "queues": {
+    "producers": [
+      { "binding": "MY_QUEUE", "queue": "my-queue" }
+    ],
+    "consumers": [
+      {
+        "queue": "my-queue",
+        "max_batch_size": 10,
+        "max_batch_timeout": 30
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Containers
+
+### Build and Push Images
+
+```bash
+# Build container image
+wrangler containers build -t my-app:latest .
+
+# Build and push in one command
+wrangler containers build -t my-app:latest . --push
+
+# Push existing image to Cloudflare registry
+wrangler containers push my-app:latest
+```
+
+### Manage Containers
+
+```bash
+# List containers
+wrangler containers list
+
+# Get container info
+wrangler containers info <CONTAINER_ID>
+
+# Delete container
+wrangler containers delete <CONTAINER_ID>
+```
+
+### Manage Images
+
+```bash
+# List images in registry
+wrangler containers images list
+
+# Delete image
+wrangler containers images delete my-app:latest
+```
+
+### Manage External Registries
+
+```bash
+# List configured registries
+wrangler containers registries list
+
+# Configure external registry (e.g., ECR)
+wrangler containers registries configure <DOMAIN> \
+  --public-credential <AWS_ACCESS_KEY_ID>
+
+# Delete registry configuration
+wrangler containers registries delete <DOMAIN>
+```
+
+---
+
+## Workflows
+
+### Manage Workflows
+
+```bash
+# List workflows
+wrangler workflows list
+
+# Describe workflow
+wrangler workflows describe my-workflow
+
+# Trigger workflow instance
+wrangler workflows trigger my-workflow
+
+# Trigger with parameters
+wrangler workflows trigger my-workflow --params '{"key": "value"}'
+
+# Delete workflow
+wrangler workflows delete my-workflow
+```
+
+### Manage Workflow Instances
+
+```bash
+# List instances
+wrangler workflows instances list my-workflow
+
+# Describe instance
+wrangler workflows instances describe my-workflow <INSTANCE_ID>
+
+# Terminate instance
+wrangler workflows instances terminate my-workflow <INSTANCE_ID>
+```
+
+### Config Binding
+
+```jsonc
+{
+  "workflows": [
+    {
+      "binding": "MY_WORKFLOW",
+      "name": "my-workflow",
+      "class_name": "MyWorkflow"
+    }
+  ]
+}
+```
+
+---
+
+## Pipelines
+
+### Manage Pipelines
+
+```bash
+# Create pipeline
+wrangler pipelines create my-pipeline --r2 my-bucket
+
+# List pipelines
+wrangler pipelines list
+
+# Show pipeline details
+wrangler pipelines show my-pipeline
+
+# Update pipeline
+wrangler pipelines update my-pipeline --batch-max-mb 100
+
+# Delete pipeline
+wrangler pipelines delete my-pipeline
+```
+
+### Config Binding
+
+```jsonc
+{
+  "pipelines": [
+    { "binding": "MY_PIPELINE", "pipeline": "my-pipeline" }
+  ]
+}
+```
+
+---
+
+## Secrets Store
+
+### Manage Stores
+
+```bash
+# Create store
+wrangler secrets-store store create my-store
+
+# List stores
+wrangler secrets-store store list
+
+# Delete store
+wrangler secrets-store store delete <STORE_ID>
+```
+
+### Manage Secrets in Store
+
+```bash
+# Add secret to store
+wrangler secrets-store secret put <STORE_ID> my-secret
+
+# List secrets in store
+wrangler secrets-store secret list <STORE_ID>
+
+# Get secret
+wrangler secrets-store secret get <STORE_ID> my-secret
+
+# Delete secret from store
+wrangler secrets-store secret delete <STORE_ID> my-secret
+```
+
+### Config Binding
+
+```jsonc
+{
+  "secrets_store_secrets": [
+    {
+      "binding": "MY_SECRET",
+      "store_id": "<STORE_ID>",
+      "secret_name": "my-secret"
+    }
+  ]
+}
+```
+
+---
+
+## Pages (Frontend Deployment)
+
+```bash
+# Create Pages project
+wrangler pages project create my-site
+
+# Deploy directory to Pages
+wrangler pages deploy ./dist
+
+# Deploy with specific branch
+wrangler pages deploy ./dist --branch main
+
+# List deployments
+wrangler pages deployment list --project-name my-site
+```
+
+---
+
+## Observability
+
+### Tail Logs
+
+```bash
+# Stream live logs
+wrangler tail
+
+# Tail specific Worker
+wrangler tail my-worker
+
+# Filter by status
+wrangler tail --status error
+
+# Filter by search term
+wrangler tail --search "error"
+
+# JSON output
+wrangler tail --format json
+```
+
+### Config Logging
+
+```jsonc
+{
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  }
+}
+```
+
+---
+
+## Testing
+
+### Local Testing with Vitest
+
+```bash
+npm install -D @cloudflare/vitest-pool-workers vitest
+```
+
+`vitest.config.ts`:
+```typescript
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.jsonc" },
+      },
+    },
+  },
+});
+```
+
+### Test Scheduled Events
+
+```bash
+# Enable in dev
+wrangler dev --test-scheduled
+
+# Trigger via HTTP
+curl http://localhost:8787/__scheduled
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| `command not found: wrangler` | Install: `npm install -D wrangler` |
+| Auth errors | Run `wrangler login` |
+| Config validation errors | Run `wrangler check` |
+| Type errors after config change | Run `wrangler types` |
+| Local storage not persisting | Check `.wrangler/state` directory |
+| Binding undefined in Worker | Verify binding name matches config exactly |
+
+### Debug Commands
+
+```bash
+# Check auth status
+wrangler whoami
+
+# Validate config
+wrangler check
+
+# View config schema
+wrangler docs configuration
+```
+
+---
+
+## Best Practices
+
+1. **Version control `wrangler.jsonc`**: Treat as source of truth for Worker config.
+2. **Use automatic provisioning**: Omit resource IDs for auto-creation on deploy.
+3. **Run `wrangler types` in CI**: Add to build step to catch binding mismatches.
+4. **Use environments**: Separate staging/production with `env.staging`, `env.production`.
+5. **Set `compatibility_date`**: Update quarterly to get new runtime features.
+6. **Use `.dev.vars` for local secrets**: Never commit secrets to config.
+7. **Test locally first**: `wrangler dev` with local bindings before deploying.
+8. **Use `--dry-run` before major deploys**: Validate changes without deployment.


### PR DESCRIPTION
Updated README to clarify the repo's purpose and add installation instructions for agents supporting the Agent Skills standard (Claude Code, OpenCode, OpenAI Codex, Pi).

Added skills:
- `agents-sdk` - building stateful AI agents with scheduling, RPC, MCP servers, email, streaming chat
- `durable-objects` - stateful coordination, RPC, SQLite storage, alarms, WebSockets
- `wrangler` - Cloudflare Workers CLI for deploying/managing Workers, KV, R2, D1, Vectorize, Queues, Workflows
- `web-perf` - auditing Core Web Vitals using Chrome DevTools MCP

Added Apache 2.0 LICENSE.