### PR TITLE
Remove npx & mcp-remote

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,15 +1,19 @@
 {
   "mcpServers": {
     "cloudflare-docs": {
+      "type": "http",
       "url": "https://docs.mcp.cloudflare.com/mcp"
     },
     "cloudflare-bindings": {
+      "type": "http",
       "url": "https://bindings.mcp.cloudflare.com/mcp"
     },
     "cloudflare-builds": {
+      "type": "http",
       "url": "https://builds.mcp.cloudflare.com/mcp"
     },
     "cloudflare-observability": {
+      "type": "http",
       "url": "https://observability.mcp.cloudflare.com/mcp"
     }
   }


### PR DESCRIPTION
Instead of using the `mcp-remote` package which requires installing another dependency and results in some undesirable behavior of opening authentication windows automatically, we should just use the mcp authentication URL directly.