### PR TITLE
add workers-best-practices skill

### DIFF
--- a/skills/workers-best-practices/SKILL.md
+++ b/skills/workers-best-practices/SKILL.md
@@ -97,7 +97,7 @@ mkdir -p /tmp/workers-types-latest && \
 | Destructuring `ctx` (`const { waitUntil } = ctx`) | Loses `this` binding — throws "Illegal invocation" at runtime |
 | `any` on `Env` or handler params | Defeats type safety for all binding access |
 | `as unknown as T` double-cast | Hides real type incompatibilities — fix the design |
-| `implements DurableObject` (instead of `extends`) | Legacy — loses `this.ctx`, `this.env` from base class |
+| `implements` on platform base classes (instead of `extends`) | Legacy — loses `this.ctx`, `this.env`. Applies to DurableObject, WorkerEntrypoint, Workflow |
 | `env.X` inside platform base class | Should be `this.env.X` in classes extending DurableObject, WorkerEntrypoint, etc. |
 
 ## Review Workflow

--- a/skills/workers-best-practices/references/review.md
+++ b/skills/workers-best-practices/references/review.md
@@ -121,18 +121,15 @@ For executable examples, verify: `name`, `compatibility_date`, `main`. Check the
 
 ## Anti-Patterns to Flag
 
-| Anti-pattern | Why |
-|-------------|-----|
-| `any` on `Env` or handler params | Defeats type safety for all downstream binding access |
-| `as unknown as T` | Hides real type incompatibilities |
-| `@ts-ignore` without explanation | Masks errors silently |
-| `implements DurableObject` (instead of `extends`) | Legacy — loses `this.ctx`, `this.env` from base class |
-| Buffering unbounded data | `await res.text()`, `await res.json()` on streams — memory exhaustion |
-| Hardcoded secrets | Use `env` bindings and `wrangler secret put` |
-| Floating promises | `step.do()`, `fetch()` without `await` — silent bugs |
-| Non-serializable values across boundaries | `Response`, `Error` in step/queue — compiles but fails at runtime |
-| `env.X` inside class body | Should be `this.env.X` in platform base classes |
-| `this.env.X` in module export handler | Should be `env.X` parameter |
+See the full anti-patterns table in `SKILL.md`. The type-specific ones to watch for during review:
+
+- **`any` on `Env` or handler params** — defeats type safety for all downstream binding access
+- **`as unknown as T`** — hides real type incompatibilities; fix the underlying design
+- **`@ts-ignore`/`@ts-expect-error` without explanation** — masks errors silently; require a justifying comment
+- **`implements` instead of `extends` on platform base classes** — legacy pattern; loses `this.ctx`, `this.env`
+- **`env.X` inside class body** — should be `this.env.X` in platform base classes
+- **`this.env.X` in module export handler** — should be `env.X` parameter
+- **Non-serializable values across boundaries** — `Response`, `Error` in step/queue compiles but fails at runtime
 
 ---
 
@@ -155,7 +152,10 @@ Valid: plain objects, arrays, strings, numbers, booleans, null, `ArrayBuffer`, `
 
 1. **Retrieve** — fetch latest workers types, wrangler schema, and best practices page
 2. **Read full files** — not just diffs; context matters for binding access patterns
-3. **Categorize code**: illustrative (concept demo), demonstrative (functional snippet), or executable (standalone)
+3. **Categorize code** — determines what to check:
+   - **Illustrative** (concept demo, comments for most logic): verify correct API names and realistic signatures
+   - **Demonstrative** (functional snippet, would work in context): verify syntax, correct APIs, correct binding access
+   - **Executable** (standalone, runs without modification): verify compiles, runs, includes imports and config
 4. **Check types** — binding access pattern, handler signatures, no `any`, no unsafe casts
 5. **Check config** — compatibility_date, nodejs_compat, observability, secrets, binding-code consistency
 6. **Check patterns** — streaming, floating promises, global state, serialization boundaries

--- a/skills/workers-best-practices/references/rules.md
+++ b/skills/workers-best-practices/references/rules.md
@@ -2,7 +2,7 @@
 
 Each rule has an imperative summary, what to check, the correct pattern, and an anti-pattern where applicable. Code examples are plain TypeScript — no MDX components.
 
-When a rule involves config fields or API signatures that may evolve, a **Retrieve** callout reminds you to check the latest docs or types before flagging.
+When a rule involves config fields or API signatures that may evolve, a **Retrieve** callout reminds you to check the latest docs or types before flagging. All doc paths are relative to `https://developers.cloudflare.com`.
 
 ---
 
@@ -12,7 +12,7 @@ When a rule involves config fields or API signatures that may evolve, a **Retrie
 
 Set `compatibility_date` to today on new projects. Update periodically on existing ones to access new APIs and fixes.
 
-**Check**: `compatibility_date` exists and is not more than ~6 months old.
+**Check**: `compatibility_date` exists. Flag if older than 6 months.
 
 ```jsonc
 // wrangler.jsonc
@@ -110,11 +110,12 @@ async fetch(request: Request, env: Env): Promise<Response> {
 
 Correct — concatenate multiple streams:
 ```ts
-async fetch(request: Request, env: Env): Promise<Response> {
+async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   const urls = ["https://api.example.com/part-1", "https://api.example.com/part-2"];
   const { readable, writable } = new TransformStream();
 
-  const pipeline = (async () => {
+  // Track the pipeline promise — don't let it float
+  ctx.waitUntil((async () => {
     for (const url of urls) {
       const response = await fetch(url);
       if (response.body) {
@@ -122,7 +123,7 @@ async fetch(request: Request, env: Env): Promise<Response> {
       }
     }
     await writable.close();
-  })();
+  })());
 
   return new Response(readable, {
     headers: { "Content-Type": "application/octet-stream" },
@@ -356,6 +357,14 @@ Anti-pattern:
 // Floating promise — result dropped, error swallowed
 fetch("https://api.example.com/webhook", { method: "POST", body: JSON.stringify(data) });
 ```
+
+### Be aware of platform limits
+
+Workers have a 10ms CPU time limit (Bundled) or 30s (Standard/Unbound). Heavy synchronous work — tight loops, large JSON parsing, compute-intensive crypto — can hit the CPU limit and terminate the request.
+
+**Check**: compute-heavy operations that run synchronously. Consider breaking work into smaller chunks, offloading to Queues/Workflows, or using WebAssembly for CPU-intensive tasks.
+
+**Retrieve**: current limits at `/workers/platform/limits/`.
 
 ---
 


### PR DESCRIPTION
Retrieval-first skill for writing and reviewing Cloudflare Workers code against production best practices.

Content sourced from [cloudflare/cloudflare-docs#28295](https://github.com/cloudflare/cloudflare-docs/pull/28295) (21 rules across 7 sections) and the code-review skill in cloudflare-docs, distilled into agent-consumable format.

- `SKILL.md` (127 lines) — retrieval sources, quick-reference rules table, anti-patterns table, review workflow
- `references/rules.md` (454 lines) — 17 best practice rules with code examples, anti-patterns, and "Retrieve" callouts for anything that may drift
- `references/review.md` (174 lines) — type validation, config validation, binding access patterns, serialization boundaries, review process with output format

Retrieval bias: the skill opens with "Prefer retrieval over pre-training" and instructs the agent to fetch the latest workers types, wrangler config schema, and best practices page before doing any work. Mirrors the approach from the code-review skill but is fully self-contained — no dependency on project-level skills.

Dropped 3 purely operational rules from the PR (environments, custom domains/routes, static assets) and kept the 17 that are relevant to code review and authoring. Scoped to Workers-only; links to the existing `durable-objects` skill and Workflows docs for those topics.