### PR TITLE
Add cloudflare-api MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,9 @@
 {
   "mcpServers": {
+    "cloudflare-api": {
+      "type": "http",
+      "url": "https://mcp.cloudflare.com/mcp"
+    },
     "cloudflare-docs": {
       "type": "http",
       "url": "https://docs.mcp.cloudflare.com/mcp"


### PR DESCRIPTION
## Summary

- Add the new Cloudflare API MCP server (`https://mcp.cloudflare.com/mcp`)
- Provides access to the full Cloudflare API via Code Mode

Closes https://github.com/cloudflare/cloudflare-docs/issues/28477

## Test plan

- [ ] Verify MCP server is accessible