### PR TITLE
chore: Replace unsupported PRAGMA user_version

### DIFF
--- a/skills/cloudflare/references/do-storage/patterns.md
+++ b/skills/cloudflare/references/do-storage/patterns.md
@@ -2,26 +2,38 @@
 
 ## Schema Migration
 
+**Note:** `PRAGMA user_version` is **not supported** in Durable Objects SQLite storage. Use a `_sql_schema_migrations` table instead:
+
 ```typescript
 export class MyDurableObject extends DurableObject {
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.sql = ctx.storage.sql;
-    
-    // Use SQLite's built-in user_version pragma
-    const ver = this.sql.exec("PRAGMA user_version").one()?.user_version || 0;
-    
-    if (ver === 0) {
+
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS _sql_schema_migrations (
+        id INTEGER PRIMARY KEY,
+        applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+
+    const ver = this.sql
+      .exec<{ version: number }>("SELECT COALESCE(MAX(id), 0) as version FROM _sql_schema_migrations")
+      .one().version;
+
+    if (ver < 1) {
       this.sql.exec(`CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT)`);
-      this.sql.exec("PRAGMA user_version = 1");
+      this.sql.exec("INSERT INTO _sql_schema_migrations (id) VALUES (1)");
     }
-    if (ver === 1) {
+    if (ver < 2) {
       this.sql.exec(`ALTER TABLE users ADD COLUMN email TEXT`);
-      this.sql.exec("PRAGMA user_version = 2");
+      this.sql.exec("INSERT INTO _sql_schema_migrations (id) VALUES (2)");
     }
   }
 }
 ```
+
+For production apps, consider [`durable-utils`](https://github.com/lambrospetrou/durable-utils#sqlite-schema-migrations) — provides a `SQLSchemaMigrations` class that tracks executed migrations both in memory and in storage. Also see [`@cloudflare/actors` storage utilities](https://github.com/cloudflare/actors/blob/main/packages/storage/src/sql-schema-migrations.ts) — a reference implementation of the same pattern used by the Cloudflare Actors framework.
 
 ## In-Memory Caching
 


### PR DESCRIPTION
`PRAGMA user_version` is not supported in DO SQLite storage. Updated migration examples in both reference files to use a `_sql_schema_migrations` table pattern per the official Cloudflare docs (cloudflare/cloudflare-docs#28233)