### PR TITLE
[Chore] Remove Orange-to-Orange references

### DIFF
--- a/skills/cloudflare/references/bot-management/gotchas.md
+++ b/skills/cloudflare/references/bot-management/gotchas.md
@@ -4,7 +4,7 @@
 
 ### "Bot Score = 0"
 
-**Cause:** Bot Management didn't run (internal Cloudflare request, Worker routing to zone (Orange-to-Orange), or request handled before BM (Redirect Rules, etc.))  
+**Cause:** Bot Management didn't run (internal Cloudflare request, Worker routing to zone (O2O), or request handled before BM (Redirect Rules, etc.))  
 **Solution:** Check request flow and ensure Bot Management runs in request lifecycle
 
 ### "JavaScript Detections Not Working"
@@ -44,7 +44,7 @@ Issue resolves automatically after 48h. Contact Cloudflare Support if persists.
 
 ### "JA3/JA4 Missing"
 
-**Cause:** Non-HTTPS traffic, Worker routing traffic, Orange-to-Orange traffic via Worker, or Bot Management skipped  
+**Cause:** Non-HTTPS traffic, Worker routing traffic, O2O traffic via Worker, or Bot Management skipped  
 **Solution:** JA3/JA4 only available for HTTPS/TLS traffic; check request routing
 
 **JA3/JA4 Not User-Unique:** Same browser/library version = same fingerprint

--- a/skills/cloudflare/references/cache-reserve/README.md
+++ b/skills/cloudflare/references/cache-reserve/README.md
@@ -81,7 +81,7 @@ Use this checklist to verify if an asset is eligible:
 - [ ] `Vary` header is NOT `*` (can be `Accept-Encoding`)
 - [ ] Not an image transformation variant (original images OK)
 - [ ] Not a range request (no HTTP 206 support)
-- [ ] Not O2O (Orange-to-Orange) proxied request
+- [ ] Not an O2O proxied request
 
 **All boxes must be checked for Cache Reserve eligibility.**
 
@@ -93,7 +93,7 @@ Use this checklist to verify if an asset is eligible:
 - Responses with `Set-Cookie` headers
 - Responses with `Vary: *` header
 - Assets from R2 public buckets on same zone
-- O2O (Orange-to-Orange) setup requests
+- O2O setup requests
 - **Range requests** (video seeking, partial content downloads)
 
 ## Quick Start

--- a/skills/cloudflare/references/cache-reserve/gotchas.md
+++ b/skills/cloudflare/references/cache-reserve/gotchas.md
@@ -41,9 +41,9 @@
 **Cause:** Purge by tag only triggers revalidation but doesn't remove from Cache Reserve storage  
 **Solution:** Use purge by URL for immediate removal, or disable Cache Reserve then clear all data for complete removal
 
-### "O2O (Orange-to-Orange) Assets Not Caching"
+### "O2O Assets Not Caching"
 
-**Cause:** Orange-to-Orange (proxied zone requesting another proxied zone on Cloudflare) bypasses Cache Reserve  
+**Cause:** O2O (proxied zone requesting another proxied zone on Cloudflare) bypasses Cache Reserve  
 **Solution:** 
 - **What is O2O**: Zone A (proxied) → Zone B (proxied), both on Cloudflare
 - **Detection**: Check `cf-cache-status` for `BYPASS` and review request path
@@ -70,7 +70,7 @@
 | Range requests | NOT supported | HTTP 206 bypasses Cache Reserve |
 | Compression | Fetches uncompressed | Serves compressed to visitors |
 | Worker control | Zone-level only | Cannot control per-request |
-| O2O requests | Bypassed | Orange-to-Orange not eligible |
+| O2O requests | Bypassed | O2O not eligible |
 
 ## Additional Resources
 
@@ -115,7 +115,7 @@ Asset not caching in Cache Reserve?
    → Yes: Range requests bypass Cache Reserve (not supported)
    → No: Continue to step 8
 
-8. Is this an O2O (Orange-to-Orange) request?
+8. Is this an O2O request?
    → Yes: O2O bypasses Cache Reserve
    → No: Continue to step 9
 

--- a/skills/cloudflare/references/workers-for-platforms/gotchas.md
+++ b/skills/cloudflare/references/workers-for-platforms/gotchas.md
@@ -27,7 +27,7 @@ try {
 ### "Hostname Routing Issues"
 
 **Cause:** DNS proxy settings causing routing problems  
-**Solution:** Use `*/*` wildcard route which works regardless of proxy settings for orange-to-orange routing
+**Solution:** Use `*/*` wildcard route which works regardless of proxy settings for O2O routing
 
 ### "Bindings Lost on Update"
 

--- a/skills/cloudflare/references/workers-for-platforms/patterns.md
+++ b/skills/cloudflare/references/workers-for-platforms/patterns.md
@@ -80,7 +80,7 @@ export default {
 2. Route: `*.saas.com/*` → dispatch Worker
 3. Extract subdomain for routing
 
-### Orange-to-Orange (O2O) Behavior
+### O2O Behavior
 
 When customers use Cloudflare and CNAME to your Workers domain:
 


### PR DESCRIPTION
Remove "Orange-to-Orange" references (keeping them as "O2O") since we're doing the same change in Dev Docs in cloudflare/cloudflare-docs#28952. 

Details available internally in PCX-21148.