### PR TITLE
Fix Cloudflare skill docs references

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This plugin includes [Cloudflare's remote MCP servers](https://developers.cloudf
 
 | Server | Purpose |
 |--------|---------|
+| cloudflare-api | Token-efficient access to the Cloudflare API |
 | cloudflare-docs | Up-to-date Cloudflare documentation and reference |
 | cloudflare-bindings | Build Workers applications with storage, AI, and compute primitives |
 | cloudflare-builds | Manage and get insights into Workers builds |

--- a/commands/build-agent.md
+++ b/commands/build-agent.md
@@ -16,11 +16,11 @@ The user invoked this command with: $ARGUMENTS
 
 When this command is invoked:
 
-1. Read the skill file at `building-ai-agent-on-cloudflare/SKILL.md` for core guidance
-2. Reference `building-ai-agent-on-cloudflare/references/examples.md` for templates
-3. Use `building-ai-agent-on-cloudflare/references/agent-patterns.md` for tool calling and patterns
-4. Use `building-ai-agent-on-cloudflare/references/state-patterns.md` for state management
-5. Consult `building-ai-agent-on-cloudflare/references/troubleshooting.md` for common issues
+1. Read the skill file at `skills/building-ai-agent-on-cloudflare/SKILL.md` for core guidance
+2. Reference `skills/building-ai-agent-on-cloudflare/references/examples.md` for templates
+3. Use `skills/building-ai-agent-on-cloudflare/references/agent-patterns.md` for tool calling and patterns
+4. Use `skills/building-ai-agent-on-cloudflare/references/state-patterns.md` for state management
+5. Consult `skills/building-ai-agent-on-cloudflare/references/troubleshooting.md` for common issues
 
 ## Capabilities
 
@@ -34,7 +34,7 @@ When this command is invoked:
 ## Example Usage
 
 ```
-/build-agent a customer support chatbot
-/build-agent real-time coding assistant with WebSocket
-/build-agent multi-agent workflow orchestrator
+/cloudflare:build-agent a customer support chatbot
+/cloudflare:build-agent real-time coding assistant with WebSocket
+/cloudflare:build-agent multi-agent workflow orchestrator
 ```

--- a/commands/build-mcp.md
+++ b/commands/build-mcp.md
@@ -16,10 +16,10 @@ The user invoked this command with: $ARGUMENTS
 
 When this command is invoked:
 
-1. Read the skill file at `building-mcp-server-on-cloudflare/SKILL.md` for core guidance
-2. Reference `building-mcp-server-on-cloudflare/references/examples.md` for official templates
-3. Use `building-mcp-server-on-cloudflare/references/oauth-setup.md` for security and OAuth
-4. Consult `building-mcp-server-on-cloudflare/references/troubleshooting.md` for common issues
+1. Read the skill file at `skills/building-mcp-server-on-cloudflare/SKILL.md` for core guidance
+2. Reference `skills/building-mcp-server-on-cloudflare/references/examples.md` for official templates
+3. Use `skills/building-mcp-server-on-cloudflare/references/oauth-setup.md` for security and OAuth
+4. Consult `skills/building-mcp-server-on-cloudflare/references/troubleshooting.md` for common issues
 
 ## Capabilities
 
@@ -32,7 +32,7 @@ When this command is invoked:
 ## Example Usage
 
 ```
-/build-mcp a GitHub integration server
-/build-mcp database query tool with OAuth
-/build-mcp file management MCP server
+/cloudflare:build-mcp a GitHub integration server
+/cloudflare:build-mcp database query tool with OAuth
+/cloudflare:build-mcp file management MCP server
 ```

--- a/skills/building-mcp-server-on-cloudflare/SKILL.md
+++ b/skills/building-mcp-server-on-cloudflare/SKILL.md
@@ -270,5 +270,4 @@ id = "xxx"
 
 - [references/examples.md](references/examples.md) — Official templates and production examples
 - [references/oauth-setup.md](references/oauth-setup.md) — OAuth provider configuration
-- [references/tool-patterns.md](references/tool-patterns.md) — Advanced tool examples
 - [references/troubleshooting.md](references/troubleshooting.md) — Error codes and fixes

--- a/skills/cloudflare/references/durable-objects/README.md
+++ b/skills/cloudflare/references/durable-objects/README.md
@@ -167,8 +167,8 @@ npx wrangler deploy           # Deploy + auto-apply migrations
 
 ## Resources
 
-**Docs**: https://developers.cloudflare.com/durable-objects/  
-**API Reference**: https://developers.cloudflare.com/durable-objects/api/  
+**Docs**: https://developers.cloudflare.com/durable-objects/
+**API Reference**: https://developers.cloudflare.com/durable-objects/api/
 **Examples**: https://developers.cloudflare.com/durable-objects/examples/
 
 ## In This Reference
@@ -182,4 +182,3 @@ npx wrangler deploy           # Deploy + auto-apply migrations
 
 - **[DO Storage](../do-storage/README.md)** - SQLite, KV, transactions (detailed storage guide)
 - **[Workers](../workers/README.md)** - Core Workers runtime features
-- **[WebSockets](../websockets/README.md)** - WebSocket APIs and patterns

--- a/skills/cloudflare/references/tunnel/README.md
+++ b/skills/cloudflare/references/tunnel/README.md
@@ -124,6 +124,4 @@ ingress:
 
 ## See Also
 
-- [workers](../workers/) - Workers with Tunnel integration
-- [access](../access/) - Zero Trust access policies
-- [warp](../warp/) - WARP client for private networks
+- [workers](../workers/README.md) - Workers with Tunnel integration

--- a/skills/cloudflare/references/wrangler/README.md
+++ b/skills/cloudflare/references/wrangler/README.md
@@ -103,6 +103,7 @@ wrangler tail --status error      # Filter by status
 
 ## In This Reference
 
+- Authentication troubleshooting (`wrangler login`, `wrangler whoami`) is covered in [gotchas.md](./gotchas.md)
 - [configuration.md](./configuration.md) - wrangler.jsonc setup, environments, bindings
 - [api.md](./api.md) - Programmatic API (`startWorker`, `getPlatformProxy`, events)
 - [patterns.md](./patterns.md) - Common workflows and development patterns
@@ -125,7 +126,12 @@ Need to configure something?
 Development not working?
 ├─ Local differs from production → Use `wrangler dev --remote`
 ├─ Bindings not available → gotchas.md §Binding Not Available
-└─ Auth issues → wrangler login
+└─ Auth issues → gotchas.md §Authentication Issues
+
+Authentication issues?
+├─ "Not logged in" / "Unauthorized" → gotchas.md §Authentication Issues
+├─ First time deploying → `wrangler login`
+└─ Confirm active account → `wrangler whoami`
 ```
 
 ## See Also


### PR DESCRIPTION
## Summary
- align the Cloudflare slash-command docs with this repo's actual `skills/...` layout and `/cloudflare:*` command names
- remove or correct broken documentation links in the MCP, Durable Objects, Tunnel, and Wrangler references
- update the README MCP server table to include `cloudflare-api`, which is already configured in `.mcp.json`

## Testing
- not run (documentation-only changes)