### PR TITLE
fix: improve wrangler skill

### DIFF
--- a/skills/wrangler/SKILL.md
+++ b/skills/wrangler/SKILL.md
@@ -235,12 +235,16 @@ wrangler deploy --minify
 
 ### Manage Secrets
 
+> **Security**: Never pass secret values as command arguments or pipe them via `echo`.
+> Use the interactive prompt (preferred), pipe from a file, or use `secret bulk`.
+> Never output, log, or hardcode secret values in commands.
+
 ```bash
-# Set secret interactively
+# Set secret — interactive prompt (preferred, wrangler will ask for the value securely)
 wrangler secret put API_KEY
 
-# Set from stdin
-echo "secret-value" | wrangler secret put API_KEY
+# Set secret from a file (useful for PEM keys, CI environments)
+wrangler secret put PRIVATE_KEY < path/to/private-key.pem
 
 # List secrets
 wrangler secret list
@@ -248,7 +252,7 @@ wrangler secret list
 # Delete secret
 wrangler secret delete API_KEY
 
-# Bulk secrets from JSON file
+# Bulk secrets from JSON file (do not commit this file to version control)
 wrangler secret bulk secrets.json
 ```
 
@@ -492,7 +496,15 @@ wrangler vectorize query my-index --vector "[0.1, 0.2, ...]" --top-k 10
 ```bash
 # Create config
 wrangler hyperdrive create my-hyperdrive \
-  --connection-string "postgres://user:pass@host:5432/database"
+  --origin-host db.example.com \
+  --origin-port 5432 \
+  --database my-database \
+  --origin-user db-user \
+  --origin-password "$DB_PASSWORD"
+
+# Or using a connection string from an environment variable
+wrangler hyperdrive create my-hyperdrive \
+  --connection-string "$HYPERDRIVE_CONNECTION_STRING"
 
 # List configs
 wrangler hyperdrive list
@@ -501,7 +513,8 @@ wrangler hyperdrive list
 wrangler hyperdrive get <HYPERDRIVE_ID>
 
 # Update config
-wrangler hyperdrive update <HYPERDRIVE_ID> --origin-password "new-password"
+wrangler hyperdrive update <HYPERDRIVE_ID> \
+  --origin-password "$DB_PASSWORD"
 
 # Delete config
 wrangler hyperdrive delete <HYPERDRIVE_ID>
@@ -626,13 +639,19 @@ wrangler containers images delete my-app:latest
 
 ### Manage External Registries
 
+> **Security**: Never hardcode registry credentials in commands. Use environment variables.
+
 ```bash
 # List configured registries
 wrangler containers registries list
 
 # Configure external registry (e.g., ECR)
 wrangler containers registries configure <DOMAIN> \
-  --public-credential <AWS_ACCESS_KEY_ID>
+  --aws-access-key-id "$AWS_ACCESS_KEY_ID"
+
+# Configure DockerHub
+wrangler containers registries configure <DOMAIN> \
+  --dockerhub-username "$DOCKERHUB_USERNAME"
 
 # Delete registry configuration
 wrangler containers registries delete <DOMAIN>
@@ -895,3 +914,4 @@ wrangler docs configuration
 6. **Use `.dev.vars` for local secrets**: Never commit secrets to config.
 7. **Test locally first**: `wrangler dev` with local bindings before deploying.
 8. **Use `--dry-run` before major deploys**: Validate changes without deployment.
+9. **Never embed secrets in commands**: Use interactive prompts (`wrangler secret put`), file-based input (`wrangler secret bulk`), or secure CI environment variables. Never echo, log, or pass secret values as CLI arguments.


### PR DESCRIPTION
## Summary

## Changes

| Issue | Before | After |
|-------|--------|-------|
| Secret piping | `echo "secret-value" \| wrangler secret put` | Interactive prompt + `< file` redirect |
| Hyperdrive connection string | `postgres://user:pass@host:5432/database` | `"$HYPERDRIVE_CONNECTION_STRING"` env var |
| Hyperdrive password | `--origin-password "new-password"` | `--origin-password "$DB_PASSWORD"` |
| Container registry credential | `--public-credential <AWS_ACCESS_KEY_ID>` (wrong flag) | `--aws-access-key-id "$AWS_ACCESS_KEY_ID"` (correct flag + env var) |

### Additional improvements
- Added security callout blocks in Secrets and Container Registries sections
- Added best practice #9: never embed secrets in commands
- Fixed incorrect `--public-credential` flag to actual wrangler CLI flags (`--aws-access-key-id`, `--dockerhub-username`)
- Added DockerHub registry configuration example