### PR TITLE
fix: fixup cloudflare skill gaps

### DIFF
--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -53,6 +53,7 @@ Need storage?
 ├─ Key-value (config, sessions, cache) → kv/
 ├─ Relational SQL → d1/ (SQLite) or hyperdrive/ (existing Postgres/MySQL)
 ├─ Object/file storage (S3-compatible) → r2/
+├─ Versioned file trees (repos, build outputs, checkpoints) → artifacts/
 ├─ Message queue (async processing) → queues/
 ├─ Vector embeddings (AI/semantic search) → vectorize/
 ├─ Strongly-consistent per-entity state → durable-objects/ (DO storage)
@@ -147,6 +148,7 @@ Need IaC? → pulumi/ (Pulumi), terraform/ (Terraform), or api/ (REST API)
 | KV | `references/kv/` |
 | D1 | `references/d1/` |
 | R2 | `references/r2/` |
+| Artifacts | `references/artifacts/` |
 | Queues | `references/queues/` |
 | Hyperdrive | `references/hyperdrive/` |
 | DO Storage | `references/do-storage/` |

--- a/skills/cloudflare/references/artifacts/README.md
+++ b/skills/cloudflare/references/artifacts/README.md
@@ -1,0 +1,65 @@
+# Cloudflare Artifacts
+
+Store versioned file trees behind a repo-style interface that works from Workers, the REST API, and git-compatible tooling.
+
+## Overview
+
+Use **Artifacts** when the thing you need to store is a versioned filesystem tree rather than a single object, key, or SQL row.
+
+Typical Artifacts use cases:
+- Git-style repositories
+- Build outputs and deployment bundles
+- Checkpoints and generated assets
+- Shared file trees passed between developer tools and Workers
+
+Artifacts is a good fit when the same content needs to be addressable from **Workers**, the **Cloudflare API**, and **git-compatible clients**.
+
+**Prefer retrieval over memory** for current status, authentication details, route shapes, limits, and pricing. Start at `https://developers.cloudflare.com/artifacts/`.
+
+## When to Use Artifacts
+
+| Need | Use | Why |
+|------|-----|-----|
+| Versioned file trees such as repos, build outputs, checkpoints, or generated assets | Artifacts | Artifacts stores and shares **versioned filesystem content** |
+| A git-compatible workflow with `clone`, `fetch`, `pull`, or `push` | Artifacts | Artifacts exposes **git-over-HTTPS remotes** and repo-scoped tokens |
+| The same artifact accessible from Workers, HTTP APIs, and developer tooling | Artifacts | Artifacts is available through a **Workers binding**, **REST API**, and **git-compatible interface** |
+| Large files by object key, app config by key, or relational app data | R2, KV, or D1 | Use storage products directly when you need **objects, key-value entries, or SQL rows**, not versioned file trees |
+
+## Quick Start
+
+**From a Worker:**
+
+```typescript
+interface Env {
+  ARTIFACTS: Artifacts;
+}
+
+const created = await env.ARTIFACTS.create("starter-repo");
+// created.remote -> git remote URL
+// created.token -> initial repo token
+```
+
+**From the REST API:**
+
+Use the account-scoped Artifacts base URL plus Bearer auth. See `api.md` for the route layout, then verify exact request details in the live docs before shipping automation.
+
+## Reading Order
+
+| Task | Read |
+|------|------|
+| Decide whether Artifacts is the right product | README only |
+| Create or manage repos from a Worker | README → configuration.md → api.md |
+| Integrate Artifacts from an external system | README → api.md |
+| Verify exact auth, routes, limits, or pricing | Live docs first: `https://developers.cloudflare.com/artifacts/` |
+
+## In This Reference
+
+- **[api.md](api.md)** - Workers binding methods, REST routes, token and repo operations
+- **[configuration.md](configuration.md)** - Wrangler binding shape, Worker typing, REST configuration guidance
+
+## See Also
+
+- [Cloudflare Artifacts Docs](https://developers.cloudflare.com/artifacts/)
+- [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
+- [Cloudflare R2 Docs](https://developers.cloudflare.com/r2/)
+- [Cloudflare D1 Docs](https://developers.cloudflare.com/d1/)

--- a/skills/cloudflare/references/artifacts/README.md
+++ b/skills/cloudflare/references/artifacts/README.md
@@ -1,6 +1,6 @@
 # Cloudflare Artifacts
 
-Store versioned file trees behind a repo-style interface that works from Workers, the REST API, and git-compatible tooling.
+Store versioned file trees behind a repo-style interface that works from Workers, the REST API, and Git-compatible tooling.
 
 ## Overview
 
@@ -8,13 +8,16 @@ Use **Artifacts** when the thing you need to store is a versioned filesystem tre
 
 Typical Artifacts use cases:
 - Git-style repositories
+- Per-agent, per-session, or per-task repos
 - Build outputs and deployment bundles
 - Checkpoints and generated assets
 - Shared file trees passed between developer tools and Workers
 
-Artifacts is a good fit when the same content needs to be addressable from **Workers**, the **Cloudflare API**, and **git-compatible clients**.
+Artifacts is a good fit when the same content needs to be addressable from **Workers**, the **REST API**, and **Git-compatible clients**.
 
-**Prefer retrieval over memory** for current status, authentication details, route shapes, limits, and pricing. Start at `https://developers.cloudflare.com/artifacts/`.
+Artifacts is especially useful for agent and automation workflows where each unit of work should have its own isolated repo and token.
+
+**Prefer retrieval over memory** for current availability, authentication details, route shapes, limits, and pricing. Start at `https://developers.cloudflare.com/artifacts/`.
 
 ## When to Use Artifacts
 
@@ -24,6 +27,13 @@ Artifacts is a good fit when the same content needs to be addressable from **Wor
 | A git-compatible workflow with `clone`, `fetch`, `pull`, or `push` | Artifacts | Artifacts exposes **git-over-HTTPS remotes** and repo-scoped tokens |
 | The same artifact accessible from Workers, HTTP APIs, and developer tooling | Artifacts | Artifacts is available through a **Workers binding**, **REST API**, and **git-compatible interface** |
 | Large files by object key, app config by key, or relational app data | R2, KV, or D1 | Use storage products directly when you need **objects, key-value entries, or SQL rows**, not versioned file trees |
+
+## Recommended Workflow
+
+- Create one repo per agent, session, user workspace, or task when work should stay isolated.
+- Fork from a stable baseline when many repos need the same starter files or prompts.
+- Use branches only when collaborators share the same lifecycle and need to work in one repo.
+- Use namespaces to separate environments, teams, or high-rate workloads.
 
 ## Quick Start
 
@@ -41,7 +51,7 @@ const created = await env.ARTIFACTS.create("starter-repo");
 
 **From the REST API:**
 
-Use the account-scoped Artifacts base URL plus Bearer auth. See `api.md` for the route layout, then verify exact request details in the live docs before shipping automation.
+Use the namespace-scoped Artifacts base URL plus a gateway JWT. For imports from existing HTTPS remotes, use the REST API rather than the Workers binding.
 
 ## Reading Order
 
@@ -50,6 +60,7 @@ Use the account-scoped Artifacts base URL plus Bearer auth. See `api.md` for the
 | Decide whether Artifacts is the right product | README only |
 | Create or manage repos from a Worker | README → configuration.md → api.md |
 | Integrate Artifacts from an external system | README → api.md |
+| Set up agent or sandbox workflows | README → configuration.md |
 | Verify exact auth, routes, limits, or pricing | Live docs first: `https://developers.cloudflare.com/artifacts/` |
 
 ## In This Reference
@@ -60,6 +71,9 @@ Use the account-scoped Artifacts base URL plus Bearer auth. See `api.md` for the
 ## See Also
 
 - [Cloudflare Artifacts Docs](https://developers.cloudflare.com/artifacts/)
+- [Artifacts Git Protocol Docs](https://developers.cloudflare.com/artifacts/api/git-protocol/)
+- [ArtifactFS Docs](https://developers.cloudflare.com/artifacts/api/artifactfs/)
 - [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
+- [Cloudflare Durable Objects Docs](https://developers.cloudflare.com/durable-objects/)
 - [Cloudflare R2 Docs](https://developers.cloudflare.com/r2/)
 - [Cloudflare D1 Docs](https://developers.cloudflare.com/d1/)

--- a/skills/cloudflare/references/artifacts/api.md
+++ b/skills/cloudflare/references/artifacts/api.md
@@ -1,8 +1,8 @@
 # Artifacts API Reference
 
-Use Artifacts through either the **Workers binding** or the **Cloudflare REST API**.
+Use Artifacts through the **Workers binding**, the **REST control plane**, and **Git-compatible remotes**.
 
-**Prefer retrieval** for exact request and response details. The docs draft is moving quickly, so verify current behavior at `https://developers.cloudflare.com/artifacts/` before relying on specific auth flows, token formats, or route details.
+**Prefer retrieval** for exact request and response details. Verify current behavior at `https://developers.cloudflare.com/artifacts/` before relying on specific auth flows, route details, or generated binding types.
 
 ## Workers Binding
 
@@ -16,17 +16,21 @@ Artifacts exposes a Worker binding on `env.ARTIFACTS`.
 | `get(name)` | Resolve a repo handle for repo-scoped operations |
 | `list(opts?)` | List repos in a namespace |
 | `delete(name)` | Delete a repo |
-| `import(name, source)` | Import a repo from GitHub into Artifacts |
 
 ```typescript
-const created = await env.ARTIFACTS.create("starter-repo");
+const created = await env.ARTIFACTS.create("starter-repo", {
+  description: "Repository for automation experiments",
+  setDefaultBranch: "main"
+});
 const repo = await env.ARTIFACTS.get("starter-repo");
 const page = await env.ARTIFACTS.list({ limit: 10 });
 ```
 
+Use the REST API when you need to import a repo from another HTTPS remote.
+
 ### Repo Handle Methods
 
-Use a repo handle returned by `get()`, `create()`, `import()`, or `fork()`.
+Use a repo handle returned by `get()` or `create()`.
 
 | Method | Use For |
 |--------|---------|
@@ -35,7 +39,7 @@ Use a repo handle returned by `get()`, `create()`, `import()`, or `fork()`.
 | `listTokens()` | Inspect active tokens |
 | `validateToken(token)` | Check whether a token is still valid |
 | `revokeToken(tokenOrId)` | Revoke a token by ID or value |
-| `fork(target)` | Fork one repo into another |
+| `fork(name, opts?)` | Fork one repo into another |
 
 ```typescript
 const repo = await env.ARTIFACTS.get("starter-repo");
@@ -43,62 +47,82 @@ if (!repo) throw new Error("Repo not found");
 
 const info = await repo.info();
 const token = await repo.createToken("read", 3600);
+const forked = await repo.fork("starter-repo-copy", {
+  defaultBranchOnly: true
+});
 ```
 
-### Import Behavior
+### Binding Notes
 
-The docs draft shows two slightly different import entry points:
-- The **Workers binding** accepts either `owner/repo` shorthand or a full GitHub URL.
-- The **REST API** examples use a full GitHub URL.
+- Current docs describe the runtime binding surface as `create`, `get`, `list`, `delete`, and repo-handle methods like `info`, `createToken`, and `fork`.
+- Use `npx wrangler types` in the target project and treat the generated `worker-configuration.d.ts` as the source of truth for that environment.
+- If generated types appear to expose `import()` or a different `get()` shape, verify the live docs before depending on those methods.
 
-Verify current import requirements in the live docs before depending on shorthand outside the Workers binding.
+Verify current runtime behavior in the live docs before depending on methods that are not shown in the Workers binding reference.
 
 ## REST API
 
-Artifacts uses the account-scoped Cloudflare v4 API:
+Artifacts currently documents a namespace-scoped control plane:
 
 ```txt
-https://api.cloudflare.com/client/v4/accounts/{accountId}/artifacts
+https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE
 ```
 
-Requests use Bearer authentication.
+Some deployments also expose an `/edge/v1/api/...` base path. Verify the correct base URL for your environment in the live docs.
+
+Requests to the standard `/v1/api/...` routes use a **gateway JWT** with Bearer authentication.
+
+Returned repo tokens authenticate **Git operations** against the repo `remote`. They do not authenticate REST control-plane requests.
+
+Current docs show the standard Cloudflare v4 response envelope around REST results.
 
 ### Repo Routes
 
 | Route | Use For |
 |-------|---------|
-| `POST /namespaces/:namespace/repos` | Create a repo |
-| `GET /namespaces/:namespace/repos` | List repos |
-| `GET /namespaces/:namespace/repos/:name` | Read repo metadata and remote |
-| `DELETE /namespaces/:namespace/repos/:name` | Delete a repo |
-| `POST /namespaces/:namespace/repos/:name/fork` | Fork a repo |
-| `POST /namespaces/:namespace/repos/:name/import` | Import a GitHub repo |
+| `POST /repos` | Create a repo |
+| `GET /repos` | List repos |
+| `GET /repos/:name` | Read repo metadata and remote |
+| `DELETE /repos/:name` | Delete a repo |
+| `POST /repos/:name/fork` | Fork a repo |
+| `POST /repos/:name/import` | Import a public HTTPS remote |
 
 ```bash
-curl "$ARTIFACTS_BASE_URL/namespaces/$ARTIFACTS_NAMESPACE/repos" \
+curl --request POST "$ARTIFACTS_BASE_URL/repos" \
   --header "Authorization: Bearer $ARTIFACTS_JWT" \
   --header "Content-Type: application/json" \
   --data '{"name":"starter-repo"}'
 ```
 
+Important current details from the docs draft:
+- `POST /repos/:name/import` accepts a full HTTPS remote URL such as GitHub or GitLab.
+- Import supports options such as `branch`, `depth`, and `read_only`.
+- Repo metadata includes fields such as description, default branch, timestamps, and the Git `remote`.
+
 ### Token Routes
 
 | Route | Use For |
 |-------|---------|
-| `GET /namespaces/:namespace/repos/:name/tokens` | List repo tokens |
-| `POST /namespaces/:namespace/tokens` | Create a token for a repo |
-| `POST /namespaces/:namespace/tokens/validate` | Validate a token |
-| `POST /namespaces/:namespace/tokens/revoke` | Revoke a token |
+| `GET /repos/:name/tokens` | List repo tokens |
+| `POST /tokens` | Create a token for a repo |
+| `DELETE /tokens/:id` | Revoke a token by ID |
 
-Use **read** tokens for clone/fetch/pull style access and **write** tokens when a workflow needs to push or otherwise mutate a repo.
+Current docs show list-token filtering and pagination by token state. Retrieve the exact query shape from the live docs when you need token audit or cleanup workflows.
+
+Use **read** tokens for clone, fetch, pull, and indexing workflows. Use **write** tokens only when a workflow must push or otherwise mutate a repo.
 
 ## Git-Compatible Access
 
 Artifacts returns repo `remote` URLs that work with standard git-over-HTTPS tooling.
 
-Use Artifacts when you need to:
-- hand a repo remote to another tool
-- mint short-lived repo access tokens
-- move versioned file trees between Workers and external systems
+Recommended current auth pattern for local workflows:
 
-For exact git auth patterns and token handling, verify the current docs at `https://developers.cloudflare.com/artifacts/`.
+```bash
+git -c http.extraHeader="Authorization: Bearer $ARTIFACTS_TOKEN" clone "$ARTIFACTS_REMOTE" artifacts-clone
+```
+
+Use a self-contained Basic-auth remote only for short-lived commands that need credentials embedded in the URL.
+
+`read` tokens support `clone`, `fetch`, and `pull`. `git push` requires a `write` token.
+
+For large repos where startup time matters more than a full clone, Artifacts also documents **ArtifactFS**. Retrieve current details from `https://developers.cloudflare.com/artifacts/` when you need mount-style access.

--- a/skills/cloudflare/references/artifacts/api.md
+++ b/skills/cloudflare/references/artifacts/api.md
@@ -1,0 +1,104 @@
+# Artifacts API Reference
+
+Use Artifacts through either the **Workers binding** or the **Cloudflare REST API**.
+
+**Prefer retrieval** for exact request and response details. The docs draft is moving quickly, so verify current behavior at `https://developers.cloudflare.com/artifacts/` before relying on specific auth flows, token formats, or route details.
+
+## Workers Binding
+
+Artifacts exposes a Worker binding on `env.ARTIFACTS`.
+
+### Namespace Methods
+
+| Method | Use For |
+|--------|---------|
+| `create(name, opts?)` | Create a repo and receive its initial remote and token |
+| `get(name)` | Resolve a repo handle for repo-scoped operations |
+| `list(opts?)` | List repos in a namespace |
+| `delete(name)` | Delete a repo |
+| `import(name, source)` | Import a repo from GitHub into Artifacts |
+
+```typescript
+const created = await env.ARTIFACTS.create("starter-repo");
+const repo = await env.ARTIFACTS.get("starter-repo");
+const page = await env.ARTIFACTS.list({ limit: 10 });
+```
+
+### Repo Handle Methods
+
+Use a repo handle returned by `get()`, `create()`, `import()`, or `fork()`.
+
+| Method | Use For |
+|--------|---------|
+| `info()` | Read repo metadata, including the remote URL |
+| `createToken(scope?, ttl?)` | Mint a repo-scoped read or write token |
+| `listTokens()` | Inspect active tokens |
+| `validateToken(token)` | Check whether a token is still valid |
+| `revokeToken(tokenOrId)` | Revoke a token by ID or value |
+| `fork(target)` | Fork one repo into another |
+
+```typescript
+const repo = await env.ARTIFACTS.get("starter-repo");
+if (!repo) throw new Error("Repo not found");
+
+const info = await repo.info();
+const token = await repo.createToken("read", 3600);
+```
+
+### Import Behavior
+
+The docs draft shows two slightly different import entry points:
+- The **Workers binding** accepts either `owner/repo` shorthand or a full GitHub URL.
+- The **REST API** examples use a full GitHub URL.
+
+Verify current import requirements in the live docs before depending on shorthand outside the Workers binding.
+
+## REST API
+
+Artifacts uses the account-scoped Cloudflare v4 API:
+
+```txt
+https://api.cloudflare.com/client/v4/accounts/{accountId}/artifacts
+```
+
+Requests use Bearer authentication.
+
+### Repo Routes
+
+| Route | Use For |
+|-------|---------|
+| `POST /namespaces/:namespace/repos` | Create a repo |
+| `GET /namespaces/:namespace/repos` | List repos |
+| `GET /namespaces/:namespace/repos/:name` | Read repo metadata and remote |
+| `DELETE /namespaces/:namespace/repos/:name` | Delete a repo |
+| `POST /namespaces/:namespace/repos/:name/fork` | Fork a repo |
+| `POST /namespaces/:namespace/repos/:name/import` | Import a GitHub repo |
+
+```bash
+curl "$ARTIFACTS_BASE_URL/namespaces/$ARTIFACTS_NAMESPACE/repos" \
+  --header "Authorization: Bearer $ARTIFACTS_JWT" \
+  --header "Content-Type: application/json" \
+  --data '{"name":"starter-repo"}'
+```
+
+### Token Routes
+
+| Route | Use For |
+|-------|---------|
+| `GET /namespaces/:namespace/repos/:name/tokens` | List repo tokens |
+| `POST /namespaces/:namespace/tokens` | Create a token for a repo |
+| `POST /namespaces/:namespace/tokens/validate` | Validate a token |
+| `POST /namespaces/:namespace/tokens/revoke` | Revoke a token |
+
+Use **read** tokens for clone/fetch/pull style access and **write** tokens when a workflow needs to push or otherwise mutate a repo.
+
+## Git-Compatible Access
+
+Artifacts returns repo `remote` URLs that work with standard git-over-HTTPS tooling.
+
+Use Artifacts when you need to:
+- hand a repo remote to another tool
+- mint short-lived repo access tokens
+- move versioned file trees between Workers and external systems
+
+For exact git auth patterns and token handling, verify the current docs at `https://developers.cloudflare.com/artifacts/`.

--- a/skills/cloudflare/references/artifacts/configuration.md
+++ b/skills/cloudflare/references/artifacts/configuration.md
@@ -2,20 +2,17 @@
 
 ## Worker Binding
 
-Bind Artifacts in `wrangler.jsonc`:
+Configure the `artifacts` binding in your Wrangler config:
 
-```jsonc
-{
-  "artifacts": [
-    {
-      "binding": "ARTIFACTS",
-      "namespace": "default"
-    }
-  ]
-}
+```toml
+[[artifacts]]
+binding = "ARTIFACTS"
+namespace = "default"
 ```
 
 This exposes Artifacts on `env.ARTIFACTS` inside your Worker.
+
+If you authenticate with `wrangler login`, current docs say Wrangler requests `artifacts:write` by default.
 
 ## TypeScript
 
@@ -33,24 +30,37 @@ interface Env {
 }
 ```
 
-Wrangler generates the `Artifacts` type from the binding. Do not hand-roll the type unless you have to.
+Wrangler generates the `Artifacts` type from the binding. Treat the generated `worker-configuration.d.ts` file as the source of truth for your environment.
+
+## Structure Repos for Isolation
+
+Artifacts works best when autonomous work is isolated:
+- Create one repo per agent, session, sandbox, or task when work should stay separate.
+- Fork from a reviewed baseline instead of copying starter files into every new repo.
+- Use branches only when collaborators share the same lifecycle and need to work in one repo.
+- Use namespaces to separate environments, teams, or high-rate workloads.
 
 ## REST Configuration
 
-For external systems, configure the account-scoped base URL and Bearer auth:
+For external systems, configure the namespace-scoped base URL and gateway JWT:
 
 ```bash
-export ARTIFACTS_ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
-export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/${ARTIFACTS_ACCOUNT_ID}/artifacts"
 export ARTIFACTS_NAMESPACE="default"
-export ARTIFACTS_JWT="<YOUR_ARTIFACTS_JWT>"
+export ARTIFACTS_JWT="<YOUR_GATEWAY_JWT>"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
-Use environment variables or your secret manager. Do not hardcode repo tokens or API credentials.
+Some environments also expose an `/edge/v1/api/...` base path. Verify the correct host and base path in the live docs for your Artifacts environment.
+
+Use environment variables or your secret manager. Do not hardcode gateway JWTs or repo tokens.
 
 ## Repo Tokens
 
 Artifacts workflows usually involve repo-scoped tokens returned by `create()` or minted later through the binding or REST API.
+
+Keep the control plane and data plane separate:
+- Use the **Workers binding** or **REST API** with a gateway JWT to create repos and mint tokens.
+- Use repo-scoped tokens only for **Git operations** against the returned `remote`.
 
 Recommended handling:
 - Mint the narrowest scope you need: `read` or `write`
@@ -63,14 +73,20 @@ Verify the current token behavior and auth guidance in `https://developers.cloud
 
 Artifacts is designed to work with standard git-over-HTTPS clients once you have a repo `remote` and an access token.
 
-Keep the control plane and data plane separate:
-- Use the **Workers binding** or **REST API** to create repos and mint tokens
-- Use the returned **git remote** in downstream tooling that needs to clone, fetch, pull, or push
+Prefer header-based auth for local tooling so the full token stays out of the remote URL:
+
+```bash
+git -c http.extraHeader="Authorization: Bearer $ARTIFACTS_TOKEN" clone "$ARTIFACTS_REMOTE" artifacts-clone
+```
+
+Use a Basic-auth remote only for short-lived commands that need a self-contained URL.
 
 ## Retrieval Checklist
 
 Check the live docs before relying on:
+- the current Workers binding surface
 - exact token formats
 - availability or product status
-- route details for import and fork flows
+- route details for import, fork, and token-management flows
+- the correct control-plane host or `/edge/v1` base path for your environment
 - platform limits or pricing

--- a/skills/cloudflare/references/artifacts/configuration.md
+++ b/skills/cloudflare/references/artifacts/configuration.md
@@ -1,0 +1,76 @@
+# Artifacts Configuration
+
+## Worker Binding
+
+Bind Artifacts in `wrangler.jsonc`:
+
+```jsonc
+{
+  "artifacts": [
+    {
+      "binding": "ARTIFACTS",
+      "namespace": "default"
+    }
+  ]
+}
+```
+
+This exposes Artifacts on `env.ARTIFACTS` inside your Worker.
+
+## TypeScript
+
+Regenerate Worker types after adding the binding:
+
+```bash
+npx wrangler types
+```
+
+Use the generated binding type in your environment definition:
+
+```typescript
+interface Env {
+  ARTIFACTS: Artifacts;
+}
+```
+
+Wrangler generates the `Artifacts` type from the binding. Do not hand-roll the type unless you have to.
+
+## REST Configuration
+
+For external systems, configure the account-scoped base URL and Bearer auth:
+
+```bash
+export ARTIFACTS_ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
+export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/${ARTIFACTS_ACCOUNT_ID}/artifacts"
+export ARTIFACTS_NAMESPACE="default"
+export ARTIFACTS_JWT="<YOUR_ARTIFACTS_JWT>"
+```
+
+Use environment variables or your secret manager. Do not hardcode repo tokens or API credentials.
+
+## Repo Tokens
+
+Artifacts workflows usually involve repo-scoped tokens returned by `create()` or minted later through the binding or REST API.
+
+Recommended handling:
+- Mint the narrowest scope you need: `read` or `write`
+- Prefer short-lived tokens for handoff between systems
+- Revoke tokens that are no longer needed
+
+Verify the current token behavior and auth guidance in `https://developers.cloudflare.com/artifacts/` before building long-lived automation.
+
+## Git Consumers
+
+Artifacts is designed to work with standard git-over-HTTPS clients once you have a repo `remote` and an access token.
+
+Keep the control plane and data plane separate:
+- Use the **Workers binding** or **REST API** to create repos and mint tokens
+- Use the returned **git remote** in downstream tooling that needs to clone, fetch, pull, or push
+
+## Retrieval Checklist
+
+Check the live docs before relying on:
+- exact token formats
+- availability or product status
+- route details for import and fork flows
+- platform limits or pricing


### PR DESCRIPTION
Add a minimal Artifacts reference under the Cloudflare skill.

The Cloudflare skill covered several storage products but did not mention Artifacts, which left agents without guidance on when to use it or where to look up the current API and configuration details.

- add Artifacts to the storage decision tree and storage index
- add a small `references/artifacts/` bundle covering product fit, Workers binding, REST API, and Wrangler setup
- bias the reference toward live retrieval at `https://developers.cloudflare.com/artifacts/` instead of baking in limits or pricing

Docs only. No tests run.