### PR TITLE
docs(flagship): update API envelope docs and add A/B/n rollout pattern

### DIFF
--- a/skills/cloudflare/references/flagship/README.md
+++ b/skills/cloudflare/references/flagship/README.md
@@ -42,6 +42,8 @@ Feature flag service for controlling feature visibility without redeploying code
 | Design targeting rules & rollouts | `patterns.md` → `gotchas.md` |
 | Debug flag evaluation issues | `gotchas.md` → `api.md` |
 
+REST API note: management endpoints use Cloudflare v4 envelopes (`result`, `result_info`, `errors`) and snake_case fields. The `/evaluate` endpoint is the exception: it is not enveloped and returns OpenFeature-style camelCase.
+
 ## In This Reference
 
 - **[api.md](./api.md)** — REST API endpoints, binding methods, OpenFeature SDK, schemas

--- a/skills/cloudflare/references/flagship/README.md
+++ b/skills/cloudflare/references/flagship/README.md
@@ -53,6 +53,7 @@ REST API note: management endpoints use Cloudflare v4 envelopes (`result`, `resu
 
 ## See Also
 
+- **[Flagship API reference](https://developers.cloudflare.com/api/resources/flagship/)** — Source of truth for REST API paths, envelopes, and response fields
 - **[../workers/](../workers/)** — Workers runtime (Flagship runs inside Workers)
 - **[../kv/](../kv/)** — KV storage (Flagship uses KV infrastructure for flag delivery)
 - **[../wrangler/](../wrangler/)** — Wrangler CLI for deployment and config

--- a/skills/cloudflare/references/flagship/api.md
+++ b/skills/cloudflare/references/flagship/api.md
@@ -212,7 +212,7 @@ App name constraints: alphanumeric + hyphens + underscores, 1-64 chars.
 GET /apps/{app_id}/evaluate?flagKey=<key>&<context-attrs>
 ```
 
-Requires an API token with Flagship read permissions. Context attributes passed as query params. This endpoint is not wrapped in the management envelope; the SDK contract returns OpenFeature-style camelCase:
+Requires an API token with the app-scoped Flagship Evaluate permission (`com.cloudflare.api.account.flagship.app.evaluate`). Context attributes passed as query params. This endpoint is not wrapped in the management envelope; the SDK contract returns OpenFeature-style camelCase:
 
 ```json
 {

--- a/skills/cloudflare/references/flagship/api.md
+++ b/skills/cloudflare/references/flagship/api.md
@@ -162,14 +162,23 @@ Base URL: `https://api.cloudflare.com/client/v4/accounts/{account_id}/flagship`
 
 Authentication: `Authorization: Bearer <API_TOKEN>`
 
-Response envelope:
+Management endpoints use the Cloudflare v4 envelope. On success, the payload is under `result`; errors are an array under `errors`.
 
-```json
+```jsonc
 // Success
-{ "success": true, "data": <T> }
+{ "success": true, "result": <T>, "errors": [], "messages": [] }
+
+// Paginated success
+{
+  "success": true,
+  "result": [<T>],
+  "result_info": { "count": 50, "cursor": "next-cursor-or-null" },
+  "errors": [],
+  "messages": []
+}
 
 // Error
-{ "success": false, "error": "message" }
+{ "success": false, "result": null, "errors": [{ "message": "message" }], "messages": [] }
 ```
 
 ### App Endpoints
@@ -201,7 +210,7 @@ App name constraints: alphanumeric + hyphens + underscores, 1-64 chars.
 GET /apps/{app_id}/evaluate?flagKey=<key>&<context-attrs>
 ```
 
-Requires an API token with `flagship:evaluate` permission. Context attributes passed as query params. Returns:
+Requires an API token with `flagship:evaluate` permission. Context attributes passed as query params. This endpoint is not wrapped in the management envelope and returns OpenFeature-style camelCase:
 
 ```json
 {
@@ -209,6 +218,47 @@ Requires an API token with `flagship:evaluate` permission. Context attributes pa
   "value": true,
   "variant": "on",
   "reason": "TARGETING_MATCH"
+}
+```
+
+### Response Shapes
+
+**App result**
+
+```json
+{
+  "id": "app-uuid",
+  "name": "my-app",
+  "created_at": "2026-06-09T12:00:00.000Z",
+  "updated_at": "2026-06-09T12:00:00.000Z",
+  "updated_by": "user@example.com"
+}
+```
+
+**Flag result**
+
+```json
+{
+  "key": "my-flag",
+  "type": "boolean",
+  "default_variation": "off",
+  "variations": { "on": true, "off": false },
+  "rules": [],
+  "description": "Enables the new feature",
+  "enabled": true,
+  "updated_at": "2026-06-09T12:00:00.000Z",
+  "updated_by": "user@example.com"
+}
+```
+
+**Changelog entry**
+
+```json
+{
+  "flag_key": "my-flag",
+  "event": "update",
+  "after": { "key": "my-flag", "default_variation": "off", "variations": { "on": true, "off": false }, "rules": [], "enabled": true },
+  "diff": { "enabled": { "from": false, "to": true } }
 }
 ```
 
@@ -325,7 +375,7 @@ Nesting supported up to 6 levels deep.
 |-------------|---------|
 | 200 | Success (read/update/delete) |
 | 201 | Created (create) |
-| 400 | Validation error (check `error` field) |
+| 400 | Validation error (check `errors[].message`) |
 | 401 | Invalid or missing token |
 | 404 | Flag or app not found |
 | 409 | Flag key already exists (create) |

--- a/skills/cloudflare/references/flagship/api.md
+++ b/skills/cloudflare/references/flagship/api.md
@@ -212,7 +212,7 @@ App name constraints: alphanumeric + hyphens + underscores, 1-64 chars.
 GET /apps/{app_id}/evaluate?flagKey=<key>&<context-attrs>
 ```
 
-Requires an API token with the app-scoped Flagship Evaluate permission (`com.cloudflare.api.account.flagship.app.evaluate`). Context attributes passed as query params. This endpoint is not wrapped in the management envelope; the SDK contract returns OpenFeature-style camelCase:
+Requires an API token with the `com.cloudflare.account.flagship.evaluate` permission. Context attributes passed as query params. This endpoint is not wrapped in the management envelope; the SDK contract returns OpenFeature-style camelCase:
 
 ```json
 {

--- a/skills/cloudflare/references/flagship/api.md
+++ b/skills/cloudflare/references/flagship/api.md
@@ -136,6 +136,8 @@ OpenFeature.addHooks(new LoggingHook(), new TelemetryHook());
 
 ## REST API (Flag Management)
 
+Source of truth: [Cloudflare Flagship API reference](https://developers.cloudflare.com/api/resources/flagship/). Use it to verify REST paths, envelopes, response fields, and permission wording before relying on examples here.
+
 ### FIRST: Check Prerequisites
 
 Before making any REST API calls (create, read, update, delete, toggle flags), verify these environment variables are set:
@@ -210,18 +212,22 @@ App name constraints: alphanumeric + hyphens + underscores, 1-64 chars.
 GET /apps/{app_id}/evaluate?flagKey=<key>&<context-attrs>
 ```
 
-Requires an API token with `flagship:evaluate` permission. Context attributes passed as query params. This endpoint is not wrapped in the management envelope and returns OpenFeature-style camelCase:
+Requires an API token with Flagship read permissions. Context attributes passed as query params. This endpoint is not wrapped in the management envelope; the SDK contract returns OpenFeature-style camelCase:
 
 ```json
 {
   "flagKey": "my-flag",
   "value": true,
   "variant": "on",
-  "reason": "TARGETING_MATCH"
+  "reason": "SPLIT"
 }
 ```
 
-### Response Shapes
+Reasons: `TARGETING_MATCH`, `SPLIT`, `DEFAULT`, `DISABLED`.
+
+### Management Response Payloads
+
+Management endpoints are wrapped in the Cloudflare v4 envelope shown above. Common `.result` payloads:
 
 **App result**
 
@@ -261,6 +267,8 @@ Requires an API token with `flagship:evaluate` permission. Context attributes pa
   "diff": { "enabled": { "from": false, "to": true } }
 }
 ```
+
+Changelog entries include the full flag state after the change. `update` entries also include `diff`.
 
 ---
 

--- a/skills/cloudflare/references/flagship/gotchas.md
+++ b/skills/cloudflare/references/flagship/gotchas.md
@@ -70,10 +70,28 @@ const val = await env.FLAGS.getBooleanValue("gradual-rollout", false, {
 curl -X PUT -d '{"enabled": true}' ...
 
 # ✅ GOOD — GET first, modify, PUT back
-FLAG=$(curl -s -H "Authorization: Bearer $TOKEN" "$URL/flags/my-flag" | jq '.data')
+FLAG=$(curl -s -H "Authorization: Bearer $TOKEN" "$URL/flags/my-flag" | jq '.result')
 UPDATED=$(echo "$FLAG" | jq '.enabled = true')
 echo "$UPDATED" | curl -s -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d @- "$URL/flags/my-flag"
 ```
+
+### Reading REST Envelope Fields
+
+**Cause:** Management endpoints use Cloudflare v4 envelopes, not raw payloads.
+
+**Solution:** Read `.result` for successful payloads, `.result_info.cursor` for pagination, and `.errors[].message` for errors.
+
+```bash
+jq '.result'
+jq '.result_info.cursor'
+jq '.errors[].message'
+```
+
+### Mixing CamelCase and Snake Case in REST Responses
+
+**Cause:** Management API responses are public API JSON and use snake_case. Evaluation responses use OpenFeature-style camelCase.
+
+**Solution:** For management endpoints use `default_variation`, `serve_variation`, `updated_at`, `updated_by`, and changelog `flag_key`. For `/evaluate`, use `flagKey`, `variant`, and `reason`.
 
 ### FLAG_NOT_FOUND in Client Provider
 

--- a/skills/cloudflare/references/flagship/patterns.md
+++ b/skills/cloudflare/references/flagship/patterns.md
@@ -405,6 +405,48 @@ Gradually roll out to 10% of users:
 }
 ```
 
+### A/B/n (Multi-Variant) Testing
+
+To split traffic across N variants, create one rule per variant with **cumulative** rollout percentages. The engine evaluates rules in priority order and uses the rollout percentage as a cumulative upper bound — so each rule's `percentage` should be the running total up to that variant.
+
+For example, to split traffic 30 % / 40 % / 30 % across variants A, B, and C:
+
+| Variant | Share | Cumulative threshold |
+|---------|-------|----------------------|
+| A       | 30 %  | 30                   |
+| B       | 40 %  | 70                   |
+| C       | 30 %  | 100                  |
+
+```json
+"rules": [
+  {
+    "priority": 1,
+    "conditions": [],
+    "serve_variation": "variant-a",
+    "rollout": { "percentage": 30, "attribute": "targetingKey" }
+  },
+  {
+    "priority": 2,
+    "conditions": [],
+    "serve_variation": "variant-b",
+    "rollout": { "percentage": 70, "attribute": "targetingKey" }
+  },
+  {
+    "priority": 3,
+    "conditions": [],
+    "serve_variation": "variant-c",
+    "rollout": { "percentage": 100, "attribute": "targetingKey" }
+  }
+]
+```
+
+Key points:
+- Rules are evaluated lowest-priority-number first. A user who falls into rule 1's 0–30 % bucket gets `variant-a` and is not evaluated further.
+- Rule 2's 70 % threshold covers the next 40 % of users (31–70 %).
+- Rule 3's 100 % threshold catches the remaining 30 % (71–100 %).
+- Always set the last rule to `100` so every user is assigned a variant.
+- Use an empty `conditions: []` array to match all users (no targeting filter).
+
 ### Progressive Rollout Workflow
 
 1. Create flag with 5% rollout, enable it

--- a/skills/cloudflare/references/flagship/patterns.md
+++ b/skills/cloudflare/references/flagship/patterns.md
@@ -409,6 +409,8 @@ Gradually roll out to 10% of users:
 
 To split traffic across N variants, create one rule per variant with **cumulative** rollout percentages. Flagship evaluates rules in priority order. If a rule's conditions match but the user misses that rule's rollout percentage, evaluation continues to the next rule. Use the same stable rollout attribute on every rule so each user is compared against the same bucket as the thresholds increase.
 
+The example uses `conditions: []` because the rules are intended to match every context. For sticky user assignment, callers must still pass the configured bucketing attribute (`targetingKey` here); otherwise Flagship uses a random bucket per request.
+
 For example, to split traffic 30% / 40% / 30% across variants A, B, and C:
 
 | Variant | Share | Cumulative threshold |
@@ -421,25 +423,19 @@ For example, to split traffic 30% / 40% / 30% across variants A, B, and C:
 "rules": [
   {
     "priority": 1,
-    "conditions": [
-      { "attribute": "targetingKey", "operator": "not_equals", "value": "" }
-    ],
+    "conditions": [],
     "serve_variation": "variant-a",
     "rollout": { "percentage": 30, "attribute": "targetingKey" }
   },
   {
     "priority": 2,
-    "conditions": [
-      { "attribute": "targetingKey", "operator": "not_equals", "value": "" }
-    ],
+    "conditions": [],
     "serve_variation": "variant-b",
     "rollout": { "percentage": 70, "attribute": "targetingKey" }
   },
   {
     "priority": 3,
-    "conditions": [
-      { "attribute": "targetingKey", "operator": "not_equals", "value": "" }
-    ],
+    "conditions": [],
     "serve_variation": "variant-c",
     "rollout": { "percentage": 100, "attribute": "targetingKey" }
   }

--- a/skills/cloudflare/references/flagship/patterns.md
+++ b/skills/cloudflare/references/flagship/patterns.md
@@ -205,11 +205,11 @@ curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags?limit=50" | jq .
 ```
 
-If `nextCursor` is non-null, fetch the next page:
+If `result_info.cursor` is non-null, fetch the next page:
 
 ```bash
 curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-  "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags?limit=50&cursor=<nextCursor>" | jq .
+  "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags?limit=50&cursor=<cursor>" | jq .
 ```
 
 ### Update a Flag (Full Replace)
@@ -219,7 +219,7 @@ Updates use PUT with the full `FlagDefinition`. Always GET first, modify, then P
 ```bash
 # 1. Read current flag
 FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-  "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags/new-feature" | jq '.data')
+  "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags/new-feature" | jq '.result')
 
 # 2. Modify (e.g., enable the flag)
 UPDATED=$(echo "$FLAG" | jq '.enabled = true')
@@ -239,7 +239,7 @@ Read-modify-write to set `enabled: true`:
 ```bash
 BASE="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags"
 
-FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/new-feature" | jq '.data')
+FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/new-feature" | jq '.result')
 UPDATED=$(echo "$FLAG" | jq '.enabled = true')
 echo "$UPDATED" | curl -s -X PUT \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
@@ -254,7 +254,7 @@ Same pattern, set `enabled: false`. The flag immediately returns its default var
 ```bash
 BASE="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags"
 
-FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/new-feature" | jq '.data')
+FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/new-feature" | jq '.result')
 UPDATED=$(echo "$FLAG" | jq '.enabled = false')
 echo "$UPDATED" | curl -s -X PUT \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
@@ -269,7 +269,7 @@ Append a rule to the existing rules array. Pick a priority that doesn't collide 
 ```bash
 BASE="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags"
 
-FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/new-feature" | jq '.data')
+FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/new-feature" | jq '.result')
 UPDATED=$(echo "$FLAG" | jq '.rules += [{
   "priority": 2,
   "conditions": [{ "attribute": "plan", "operator": "equals", "value": "enterprise" }],
@@ -288,7 +288,7 @@ Update the rollout percentage on an existing rule (e.g., rule at index 0):
 ```bash
 BASE="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags"
 
-FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/gradual-rollout" | jq '.data')
+FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/gradual-rollout" | jq '.result')
 UPDATED=$(echo "$FLAG" | jq '.rules[0].rollout.percentage = 50')
 echo "$UPDATED" | curl -s -X PUT \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
@@ -301,7 +301,7 @@ echo "$UPDATED" | curl -s -X PUT \
 ```bash
 BASE="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags"
 
-FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/new-feature" | jq '.data')
+FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/new-feature" | jq '.result')
 UPDATED=$(echo "$FLAG" | jq '.default_variation = "on"')
 echo "$UPDATED" | curl -s -X PUT \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
@@ -314,7 +314,7 @@ echo "$UPDATED" | curl -s -X PUT \
 ```bash
 BASE="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags"
 
-FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/checkout-flow" | jq '.data')
+FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/checkout-flow" | jq '.result')
 UPDATED=$(echo "$FLAG" | jq '.variations["treatment-c"] = "minimal"')
 echo "$UPDATED" | curl -s -X PUT \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
@@ -329,7 +329,7 @@ Remove a rule by filtering on priority:
 ```bash
 BASE="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/flagship/apps/$FLAGSHIP_APP_ID/flags"
 
-FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/new-feature" | jq '.data')
+FLAG=$(curl -s -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" "$BASE/new-feature" | jq '.result')
 UPDATED=$(echo "$FLAG" | jq '.rules = [.rules[] | select(.priority != 2)]')
 echo "$UPDATED" | curl -s -X PUT \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \

--- a/skills/cloudflare/references/flagship/patterns.md
+++ b/skills/cloudflare/references/flagship/patterns.md
@@ -407,33 +407,39 @@ Gradually roll out to 10% of users:
 
 ### A/B/n (Multi-Variant) Testing
 
-To split traffic across N variants, create one rule per variant with **cumulative** rollout percentages. The engine evaluates rules in priority order and uses the rollout percentage as a cumulative upper bound — so each rule's `percentage` should be the running total up to that variant.
+To split traffic across N variants, create one rule per variant with **cumulative** rollout percentages. Flagship evaluates rules in priority order. If a rule's conditions match but the user misses that rule's rollout percentage, evaluation continues to the next rule. Use the same stable rollout attribute on every rule so each user is compared against the same bucket as the thresholds increase.
 
-For example, to split traffic 30 % / 40 % / 30 % across variants A, B, and C:
+For example, to split traffic 30% / 40% / 30% across variants A, B, and C:
 
 | Variant | Share | Cumulative threshold |
 |---------|-------|----------------------|
-| A       | 30 %  | 30                   |
-| B       | 40 %  | 70                   |
-| C       | 30 %  | 100                  |
+| A       | 30%   | 30                   |
+| B       | 40%   | 70                   |
+| C       | 30%   | 100                  |
 
 ```json
 "rules": [
   {
     "priority": 1,
-    "conditions": [],
+    "conditions": [
+      { "attribute": "targetingKey", "operator": "not_equals", "value": "" }
+    ],
     "serve_variation": "variant-a",
     "rollout": { "percentage": 30, "attribute": "targetingKey" }
   },
   {
     "priority": 2,
-    "conditions": [],
+    "conditions": [
+      { "attribute": "targetingKey", "operator": "not_equals", "value": "" }
+    ],
     "serve_variation": "variant-b",
     "rollout": { "percentage": 70, "attribute": "targetingKey" }
   },
   {
     "priority": 3,
-    "conditions": [],
+    "conditions": [
+      { "attribute": "targetingKey", "operator": "not_equals", "value": "" }
+    ],
     "serve_variation": "variant-c",
     "rollout": { "percentage": 100, "attribute": "targetingKey" }
   }
@@ -441,11 +447,12 @@ For example, to split traffic 30 % / 40 % / 30 % across variants A, B, and C:
 ```
 
 Key points:
-- Rules are evaluated lowest-priority-number first. A user who falls into rule 1's 0–30 % bucket gets `variant-a` and is not evaluated further.
-- Rule 2's 70 % threshold covers the next 40 % of users (31–70 %).
-- Rule 3's 100 % threshold catches the remaining 30 % (71–100 %).
-- Always set the last rule to `100` so every user is assigned a variant.
-- Use an empty `conditions: []` array to match all users (no targeting filter).
+- Rules are evaluated lowest-priority-number first. A user who falls into rule 1's 0-30% bucket gets `variant-a` and is not evaluated further.
+- Rule 2's 70% threshold covers the next 40% of users (31-70%).
+- Rule 3's 100% threshold catches the remaining 30% (71-100%).
+- Always set the last rule to `100` so every context with the bucketing attribute is assigned a variant.
+- For sticky A/B/n assignment, pass a stable `targetingKey` or configured bucketing attribute. Without it, rollout assignment is random per request, which can be useful for request-level sampling but is usually wrong for user experiments.
+- A percentage rollout match reports reason `SPLIT` in evaluation details.
 
 ### Progressive Rollout Workflow
 


### PR DESCRIPTION
Updates Flagship Cloudflare skill references for current control-plane behavior and adds guidance for multi-variant A/B/n experiments.

Changes:
- Document current Cloudflare v4 response envelope for management endpoints:
  - payloads under `result`
  - pagination cursor under `result_info.cursor`
  - errors under `errors[].message`
- Remove unsupported legacy response-field usage from examples.
- Update REST examples to use `jq '.result'`.
- Clarify management API response casing:
  - snake_case fields such as `created_at`, `updated_at`, `updated_by`, `default_variation`, `serve_variation`, and changelog `flag_key`
- Clarify `/evaluate` response behavior:
  - not wrapped in management envelope
  - OpenFeature-style camelCase (`flagKey`, `variant`, `reason`)
- Add response-shape examples for apps, flags, and changelog entries.
- Add gotchas for envelope access and casing differences between management responses and evaluation responses.
- Add A/B/n multi-variant testing pattern:
  - one rule per variant
  - cumulative rollout thresholds
  - example 30% / 40% / 30% split across variants A/B/C
  - guidance to use `conditions: []` and set final threshold to `100`

Validation:
- Reviewed branch diff against `origin/main`.
- Verified no unsupported `.data`, `nextCursor`, or single `.error` references remain in Flagship docs.
