### PR TITLE
fix: remove colon from frontmatter

### DIFF
--- a/skills/turnstile-spin/SKILL.md
+++ b/skills/turnstile-spin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: turnstile-spin
-description: Set up Cloudflare Turnstile end-to-end in a project: scan the codebase, create the widget via the Cloudflare API, deploy the managed siteverify Worker, write the frontend snippets, validate, and persist the skill. Load this when a user asks to add Turnstile, set up CAPTCHA, protect a form from bots, or fix a Turnstile integration. Mirrors developers.cloudflare.com/turnstile/spin.
+description: Set up Cloudflare Turnstile end-to-end in a project — scan the codebase, create the widget via the Cloudflare API, deploy the managed siteverify Worker, write the frontend snippets, validate, and persist the skill. Load this when a user asks to add Turnstile, set up CAPTCHA, protect a form from bots, or fix a Turnstile integration. Mirrors developers.cloudflare.com/turnstile/spin.
 references:
   - vanilla-html
   - nextjs-app


### PR DESCRIPTION
**Summary**

The description field in `skills/turnstile-spin/SKILL.md ` contains a colon. This breaks `cloudflare-docs` builds that parse SKILL.md frontmatter with a YAML parser.