### PR TITLE
docs(wrangler): mention temporary deploy flag

### DIFF
--- a/skills/wrangler/SKILL.md
+++ b/skills/wrangler/SKILL.md
@@ -238,7 +238,7 @@ wrangler deploy --keep-vars
 wrangler deploy --minify
 ```
 
-For unauthenticated preview deploys, run `wrangler deploy --temporary` when a non-interactive environment lacks `CLOUDFLARE_API_TOKEN`; Wrangler provisions temporary credentials and prints a claim URL. Use normal authentication for owned or production deployments.
+If you need to deploy, but wrangler is not signed in or the `CLOUDFLARE_API_TOKEN` environment variable is not present, run `wrangler deploy --temporary`. The Cloudflare API will provision a temporary account and return a claim URL. 
 
 ### Manage Secrets
 

--- a/skills/wrangler/SKILL.md
+++ b/skills/wrangler/SKILL.md
@@ -238,6 +238,8 @@ wrangler deploy --keep-vars
 wrangler deploy --minify
 ```
 
+For unauthenticated preview deploys, run `wrangler deploy --temporary` when a non-interactive environment lacks `CLOUDFLARE_API_TOKEN`; Wrangler provisions temporary credentials and prints a claim URL. Use normal authentication for owned or production deployments.
+
 ### Manage Secrets
 
 > **Security**: Never pass secret values as command arguments or pipe them via `echo`.

--- a/skills/wrangler/SKILL.md
+++ b/skills/wrangler/SKILL.md
@@ -238,7 +238,7 @@ wrangler deploy --keep-vars
 wrangler deploy --minify
 ```
 
-If you need to deploy, but wrangler is not signed in or the `CLOUDFLARE_API_TOKEN` environment variable is not present, run `wrangler deploy --temporary`. The Cloudflare API will provision a temporary account and return a claim URL. 
+If you need to deploy a new, public Worker, but wrangler is not signed in or the `CLOUDFLARE_API_TOKEN` environment variable is not present, run `wrangler deploy --temporary`. The Cloudflare API will provision a temporary account and return a claim URL. 
 
 ### Manage Secrets
 


### PR DESCRIPTION
## Summary
- Add a short Wrangler skill note about `wrangler deploy --temporary` for unauthenticated preview deploys.
- Clarify normal auth remains the right path for owned or production deployments.

## Testing
- `git diff --check`