### PR TITLE
fix(agents-sdk): update dead links to match restructured Cloudflare docs

### DIFF
--- a/skills/agents-sdk/SKILL.md
+++ b/skills/agents-sdk/SKILL.md
@@ -25,27 +25,27 @@ Cloudflare docs: https://developers.cloudflare.com/agents/
 | HTTP/WebSockets | [WebSockets](https://developers.cloudflare.com/agents/api-reference/websockets/) | Lifecycle hooks, hibernation |
 | Chat agents | [Chat agents](https://developers.cloudflare.com/agents/api-reference/chat-agents/) | `AIChatAgent`, streaming, tools, persistence |
 | Client SDK | [Client SDK](https://developers.cloudflare.com/agents/api-reference/client-sdk/) | `useAgent`, `useAgentChat`, React hooks |
-| Client tools | [Client tools](https://developers.cloudflare.com/agents/api-reference/client-tools/) | Client-side tools, `autoContinueAfterToolResult` |
-| Server-driven messages | [Trigger patterns](https://developers.cloudflare.com/agents/api-reference/trigger-patterns/) | `saveMessages`, `waitUntilStable`, server-initiated turns |
-| Resumable streaming | [Resumable streaming](https://developers.cloudflare.com/agents/api-reference/resumable-streaming/) | Stream recovery on disconnect |
+| Client tools | [Client tools](https://developers.cloudflare.com/agents/harnesses/think/client-tools/) | Client-side tools, `autoContinueAfterToolResult` |
+| Server-driven messages | [Autonomous responses](https://developers.cloudflare.com/agents/communication-channels/chat/autonomous-responses/) | `saveMessages`, `waitUntilStable`, server-initiated turns |
+| Resumable streaming | [Chat agents](https://developers.cloudflare.com/agents/communication-channels/chat/chat-agents/#resumable-streaming) | Stream recovery on disconnect |
 | Email | [Email](https://developers.cloudflare.com/agents/api-reference/email/) | Email routing, secure reply resolver |
 | MCP client | [MCP client](https://developers.cloudflare.com/agents/api-reference/mcp-client-api/) | Connecting to MCP servers |
 | MCP server | [MCP server](https://developers.cloudflare.com/agents/api-reference/mcp-agent-api/) | Building MCP servers with `McpAgent` |
-| MCP transports | [MCP transports](https://developers.cloudflare.com/agents/api-reference/mcp-transports/) | Streamable HTTP, SSE, RPC transport options |
-| Securing MCP servers | [Securing MCP](https://developers.cloudflare.com/agents/api-reference/securing-mcp-servers/) | OAuth, proxy MCP, hardening |
+| MCP transports | [MCP transports](https://developers.cloudflare.com/agents/model-context-protocol/protocol/transport/) | Streamable HTTP, SSE, RPC transport options |
+| Securing MCP servers | [Securing MCP](https://developers.cloudflare.com/agents/model-context-protocol/guides/securing-mcp-server/) | OAuth, proxy MCP, hardening |
 | Human-in-the-loop | [Human-in-the-loop](https://developers.cloudflare.com/agents/concepts/human-in-the-loop/) | Approval flows, `needsApproval`, workflows |
 | Durable execution | [Durable execution](https://developers.cloudflare.com/agents/api-reference/durable-execution/) | `runFiber()`, `stash()`, surviving DO eviction |
 | Queue | [Queue](https://developers.cloudflare.com/agents/api-reference/queue-tasks/) | Built-in FIFO queue, `queue()` |
 | Retries | [Retries](https://developers.cloudflare.com/agents/api-reference/retries/) | `this.retry()`, backoff/jitter |
 | Observability | [Observability](https://developers.cloudflare.com/agents/api-reference/observability/) | Diagnostics-channel events |
-| Push notifications | [Push notifications](https://developers.cloudflare.com/agents/api-reference/push-notifications/) | Web Push + VAPID from agents |
-| Webhooks | [Webhooks](https://developers.cloudflare.com/agents/api-reference/webhooks/) | Receiving external webhooks |
-| Cross-domain auth | [Cross-domain auth](https://developers.cloudflare.com/agents/api-reference/cross-domain-authentication/) | WebSocket auth, tokens, CORS |
+| Push notifications | [Push notifications](https://developers.cloudflare.com/agents/communication-channels/webhooks/push-notifications/) | Web Push + VAPID from agents |
+| Webhooks | [Webhooks](https://developers.cloudflare.com/agents/communication-channels/webhooks/) | Receiving external webhooks |
+| Cross-domain auth | [Cross-domain auth](https://developers.cloudflare.com/agents/runtime/operations/cross-domain-authentication/) | WebSocket auth, tokens, CORS |
 | Readonly connections | [Readonly](https://developers.cloudflare.com/agents/api-reference/readonly-connections/) | `shouldConnectionBeReadonly` |
 | Voice | [Voice](https://developers.cloudflare.com/agents/api-reference/voice/) | Experimental STT/TTS, `withVoice` |
 | Browse the web | [Browser tools](https://developers.cloudflare.com/agents/api-reference/browse-the-web/) | Experimental CDP browser automation |
 | Think | [Think](https://developers.cloudflare.com/agents/api-reference/think/) | Experimental higher-level chat agent class |
-| Migrations | [AI SDK v5](https://developers.cloudflare.com/agents/guides/migration-to-ai-sdk-v5/), [AI SDK v6](https://developers.cloudflare.com/agents/guides/migration-to-ai-sdk-v6/) | Upgrading `@cloudflare/ai-chat` |
+| Migrations | [AI SDK v5](https://github.com/cloudflare/agents/blob/main/docs/agents/migration-to-ai-sdk-v5.md), [AI SDK v6](https://github.com/cloudflare/agents/blob/main/docs/agents/migration-to-ai-sdk-v6.md) | Upgrading `@cloudflare/ai-chat` |
 
 ## Capabilities
 

--- a/skills/agents-sdk/references/mcp.md
+++ b/skills/agents-sdk/references/mcp.md
@@ -155,7 +155,7 @@ export default {
 
 ## Transports
 
-Fetch https://developers.cloudflare.com/agents/api-reference/mcp-transports/ for complete documentation.
+Fetch https://developers.cloudflare.com/agents/model-context-protocol/protocol/transport/ for complete documentation.
 
 | Transport | Use for |
 |-----------|---------|
@@ -183,6 +183,6 @@ await this.addMcpServer("tools", url, {
 
 ## Securing MCP Servers
 
-Fetch https://developers.cloudflare.com/agents/api-reference/securing-mcp-servers/ for complete documentation.
+Fetch https://developers.cloudflare.com/agents/model-context-protocol/guides/securing-mcp-server/ for complete documentation.
 
 Use `@cloudflare/workers-oauth-provider` to add OAuth in front of your MCP server. See the securing docs for proxy patterns and `redirect_uri` validation.

--- a/skills/agents-sdk/references/server-driven-messages.md
+++ b/skills/agents-sdk/references/server-driven-messages.md
@@ -1,6 +1,6 @@
 # Server-Driven Messages (Trigger Patterns)
 
-Fetch https://developers.cloudflare.com/agents/api-reference/trigger-patterns/ for complete documentation.
+Fetch https://developers.cloudflare.com/agents/communication-channels/chat/autonomous-responses/ for complete documentation.
 
 Patterns for server-initiated LLM turns in `AIChatAgent` — from schedules, webhooks, email, or other agents.
 

--- a/skills/agents-sdk/references/webhooks-push.md
+++ b/skills/agents-sdk/references/webhooks-push.md
@@ -2,7 +2,7 @@
 
 ## Webhooks
 
-Fetch https://developers.cloudflare.com/agents/api-reference/webhooks/ for complete documentation.
+Fetch https://developers.cloudflare.com/agents/communication-channels/webhooks/ for complete documentation.
 
 Route external webhooks to agent instances via `onRequest`:
 
@@ -40,7 +40,7 @@ export class MyAgent extends Agent<Env, State> {
 
 ## Push Notifications
 
-Fetch https://developers.cloudflare.com/agents/api-reference/push-notifications/ for complete documentation.
+Fetch https://developers.cloudflare.com/agents/communication-channels/webhooks/push-notifications/ for complete documentation.
 
 Web Push via VAPID from agents. Store subscriptions in agent state, send via `web-push`.
 


### PR DESCRIPTION
Some links in the agents-sdk SKILL.md and references/ files have become dead links (404 Page Not Found), mainly due to the docs restructure in cloudflare/cloudflare-docs#31098.

The agents/api-reference/ path has been split into sub-paths such as agents/communication-channels/, agents/model-context-protocol/, agents/runtime/, and agents/harnesses/. Some page titles have also changed.

I've verified locally that none of the new URLs return 404. If any reference target is wrong, please let me know.

## Dead links fixed

| Old path | New path | Note |
|----------|----------|------|
| `agents/api-reference/webhooks/` | `agents/communication-channels/webhooks/` | [Renamed](https://github.com/cloudflare/cloudflare-docs/blob/e7b2d47d/src/content/docs/agents/guides/webhooks.mdx) in #31098 |
| `agents/api-reference/push-notifications/` | `agents/communication-channels/webhooks/push-notifications/` | [Renamed](https://github.com/cloudflare/cloudflare-docs/blob/e7b2d47d/src/content/docs/agents/guides/push-notifications.mdx) in #31098 |
| `agents/api-reference/client-tools/` | `agents/harnesses/think/client-tools/` | [Renamed](https://github.com/cloudflare/cloudflare-docs/blob/e7b2d47d/src/content/docs/agents/think/client-tools.mdx) in #31098 |
| `agents/api-reference/trigger-patterns/` | `agents/communication-channels/chat/autonomous-responses/` | Page never existed at `api-reference/`; points to [equivalent content](https://github.com/cloudflare/cloudflare-docs/blob/e7b2d47d/src/content/docs/agents/guides/autonomous-responses.mdx) |
| `agents/api-reference/resumable-streaming/` | `agents/communication-channels/chat/chat-agents/#resumable-streaming` | Page never existed in cloudflare-docs; covered as a section in chat agents |
| `agents/api-reference/mcp-transports/` | `agents/model-context-protocol/protocol/transport/` | [Renamed](https://github.com/cloudflare/cloudflare-docs/blob/e7b2d47d/src/content/docs/agents/model-context-protocol/transport.mdx) in #31098 |
| `agents/api-reference/securing-mcp-servers/` | `agents/model-context-protocol/guides/securing-mcp-server/` | [Renamed](https://github.com/cloudflare/cloudflare-docs/blob/e7b2d47d/src/content/docs/agents/guides/securing-mcp-server.mdx) in #31098 |
| `agents/api-reference/cross-domain-authentication/` | `agents/runtime/operations/cross-domain-authentication/` | [Renamed](https://github.com/cloudflare/cloudflare-docs/blob/e7b2d47d/src/content/docs/agents/guides/cross-domain-authentication.mdx) in #31098 |
| `agents/guides/migration-to-ai-sdk-v5/` | [GitHub (cloudflare/agents)](https://github.com/cloudflare/agents/blob/main/docs/agents/migration-to-ai-sdk-v5.md) | Removed from docs site |
| `agents/guides/migration-to-ai-sdk-v6/` | [GitHub (cloudflare/agents)](https://github.com/cloudflare/agents/blob/main/docs/agents/migration-to-ai-sdk-v6.md) | Removed from docs site |
