### PR TITLE
Fix SQL syntax for error rate calculation in Analytics Engine

### DIFF
--- a/skills/cloudflare/references/analytics-engine/api.md
+++ b/skills/cloudflare/references/analytics-engine/api.md
@@ -84,7 +84,7 @@ GROUP BY blob1 ORDER BY requests DESC LIMIT 20
 
 -- Error rate
 SELECT blob1, COUNT(*) AS total,
-  SUM(CASE WHEN blob3 LIKE '5%' THEN 1 ELSE 0 END) AS errors
+  SUM(if(blob3 LIKE '5%', 1, 0)) AS errors
 FROM api_requests WHERE timestamp >= NOW() - INTERVAL '1' HOUR
 GROUP BY blob1 HAVING total > 50
 


### PR DESCRIPTION
 #### Summary

 Fixes an invalid SQL query example in the Workers Analytics Engine documentation (references/analytics-engine/api.md).

 The Workers Analytics Engine SQL API is built on a restricted time-series SQL engine that does not support standard SQL CASE WHEN ... THEN ... END expressions.
 Attempting to execute a query using CASE WHEN results in an HTTP 422 error:

 ```
   Error: Analytics API error (422): Input was invalid: unsupported expression type: CASE WHEN ...
 ```

 The supported syntax for conditional logic in Workers Analytics Engine SQL is the if(condition, true_value, false_value) scalar function.

 #### Changes

 - Updated the Error rate example in references/analytics-engine/api.md:
   ```sql
     -- Before
     SUM(CASE WHEN blob3 LIKE '5%' THEN 1 ELSE 0 END) AS errors

     -- After
     SUM(if(blob3 LIKE '5%', 1, 0)) AS errors
   ```

 #### References

 - Cloudflare Workers Analytics Engine SQL Reference (https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/conditional-functions/)