### PR TITLE
Point full-stack web apps to Workers instead of Pages

### DIFF
--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -45,7 +45,7 @@ Need feature flags?
 ```
 Need to run code?
 ├─ Serverless functions at the edge → workers/
-├─ Full-stack web app with Git deploys → pages/
+├─ Full-stack web app with Git deploys → workers/ (with Static Assets)
 ├─ Stateful coordination/real-time → durable-objects/
 ├─ Long-running multi-step jobs → workflows/
 ├─ Run containers → containers/


### PR DESCRIPTION
Avoid sending agents to Pages for full-stack apps — Workers with static assets is a better alternative

Open questions:
- Does info on Workers Assets need to be fleshed out first? at the moment the `.md` files under `references/workers/` really only talk about the worker script itself
- Does the Cloudflare codex plugin at https://github.com/openai/plugins/blob/main/plugins/cloudflare/skills/cloudflare/SKILL.md also need to be updated?