### PR TITLE
Fix 8 dead documentation links in cloudflare skill references

### DIFF
--- a/skills/cloudflare/references/artifacts/README.md
+++ b/skills/cloudflare/references/artifacts/README.md
@@ -72,7 +72,7 @@ Use the namespace-scoped Artifacts base URL plus a gateway JWT. For imports from
 
 - [Cloudflare Artifacts Docs](https://developers.cloudflare.com/artifacts/)
 - [Artifacts Git Protocol Docs](https://developers.cloudflare.com/artifacts/api/git-protocol/)
-- [ArtifactFS Docs](https://developers.cloudflare.com/artifacts/api/artifactfs/)
+- [ArtifactFS Docs](https://developers.cloudflare.com/artifacts/guides/artifact-fs/)
 - [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
 - [Cloudflare Durable Objects Docs](https://developers.cloudflare.com/durable-objects/)
 - [Cloudflare R2 Docs](https://developers.cloudflare.com/r2/)

--- a/skills/cloudflare/references/cron-triggers/gotchas.md
+++ b/skills/cloudflare/references/cron-triggers/gotchas.md
@@ -196,4 +196,4 @@ export default {
 - [Cloudflare Workflows](https://developers.cloudflare.com/workflows/)
 - [Workers Limits](https://developers.cloudflare.com/workers/platform/limits/)
 - [Crontab Guru](https://crontab.guru/) - Validator
-- [Vitest Pool Workers](https://github.com/cloudflare/workers-sdk/tree/main/fixtures/vitest-pool-workers-examples)
+- [Vitest Pool Workers](https://developers.cloudflare.com/workers/testing/vitest-integration/)

--- a/skills/cloudflare/references/network-interconnect/README.md
+++ b/skills/cloudflare/references/network-interconnect/README.md
@@ -29,7 +29,7 @@ Private, high-performance connectivity to Cloudflare's network. **Enterprise-onl
 - Enterprise plan
 - IPv4 /24+ or IPv6 /48+ prefixes
 - BGP ASN for v1
-- See [locations PDF](https://developers.cloudflare.com/network-interconnect/static/cni-locations-2026-01.pdf)
+- See [locations PDF](https://developers.cloudflare.com/network-interconnect/static/cni-locations-05-may-2026.pdf)
 
 ## Specs
 

--- a/skills/cloudflare/references/network-interconnect/gotchas.md
+++ b/skills/cloudflare/references/network-interconnect/gotchas.md
@@ -62,7 +62,7 @@ await client.networkInterconnects.slots.list({
 ### 400 Bad Request: "invalid facility code"
 
 **Cause:** Typo or unsupported facility  
-**Solution:** Check [locations PDF](https://developers.cloudflare.com/network-interconnect/static/cni-locations-2026-01.pdf) for valid codes
+**Solution:** Check [locations PDF](https://developers.cloudflare.com/network-interconnect/static/cni-locations-05-may-2026.pdf) for valid codes
 
 ### 403 Forbidden: "Enterprise plan required"
 

--- a/skills/cloudflare/references/network-interconnect/patterns.md
+++ b/skills/cloudflare/references/network-interconnect/patterns.md
@@ -163,4 +163,4 @@ const tertiary = await client.networkInterconnects.interconnects.create({
 
 - [Magic Transit Docs](https://developers.cloudflare.com/magic-transit/)
 - [Magic WAN Docs](https://developers.cloudflare.com/magic-wan/)
-- [Argo Smart Routing](https://developers.cloudflare.com/argo/)
+- [Argo Smart Routing](https://developers.cloudflare.com/argo-smart-routing/)

--- a/skills/cloudflare/references/pages-functions/gotchas.md
+++ b/skills/cloudflare/references/pages-functions/gotchas.md
@@ -88,7 +88,7 @@ npx wrangler pages deployment tail --status error
 
 - [Official Docs](https://developers.cloudflare.com/pages/functions/)
 - [Workers APIs](https://developers.cloudflare.com/workers/runtime-apis/)
-- [Examples](https://github.com/cloudflare/pages-example-projects)
+- [Framework guides](https://developers.cloudflare.com/pages/framework-guides/)
 - [Discord](https://discord.gg/cloudflaredev)
 
 **See also:** [configuration.md](./configuration.md) for TypeScript setup | [patterns.md](./patterns.md) for middleware/auth | [api.md](./api.md) for bindings

--- a/skills/cloudflare/references/realtime-sfu/README.md
+++ b/skills/cloudflare/references/realtime-sfu/README.md
@@ -62,4 +62,4 @@ Get `CALLS_APP_ID` and `CALLS_APP_SECRET` from dashboard, then see configuration
 - [Orange Source](https://github.com/cloudflare/orange)
 - [Calls Examples](https://github.com/cloudflare/calls-examples)
 - [API Reference](https://developers.cloudflare.com/api/resources/calls/)
-- [RealtimeKit Docs](https://developers.cloudflare.com/workers-ai/realtimekit/)
+- [RealtimeKit Docs](https://developers.cloudflare.com/realtime/realtimekit/)

--- a/skills/cloudflare/references/workers-vpc/README.md
+++ b/skills/cloudflare/references/workers-vpc/README.md
@@ -123,5 +123,5 @@ See [gotchas.md](./gotchas.md) for complete limits and troubleshooting.
 ## Reference
 
 - [TCP Sockets API Documentation](https://developers.cloudflare.com/workers/runtime-apis/tcp-sockets/)
-- [Connect to databases guide](https://developers.cloudflare.com/workers/tutorials/connect-to-postgres/)
+- [Connect to databases guide](https://developers.cloudflare.com/workers/tutorials/postgres/)
 - [Cloudflare Tunnel setup](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)

--- a/skills/cloudflare/references/wrangler/gotchas.md
+++ b/skills/cloudflare/references/wrangler/gotchas.md
@@ -186,7 +186,7 @@ const worker = await startWorker({
 - Docs: https://developers.cloudflare.com/workers/wrangler/
 - Config: https://developers.cloudflare.com/workers/wrangler/configuration/
 - Commands: https://developers.cloudflare.com/workers/wrangler/commands/
-- Examples: https://github.com/cloudflare/workers-sdk/tree/main/templates
+- Examples: https://github.com/cloudflare/templates
 - Discord: https://discord.gg/cloudflaredev
 
 ## See Also


### PR DESCRIPTION
## Problem

Nine link sites across `skills/cloudflare/references/` point at URLs that currently return **HTTP 404**. Since these skills are explicitly retrieval-first ("Prefer retrieval over pre-training"), a dead link is worse than no link — the agent fetches, gets a 404, and typically burns turns retrying variations of the guessed path.

I found these by sweeping all 349 URLs in the skill and checking every docs/GitHub link (162 of them) with `curl -L`.

## Changes

| File | Was (404) | Now (200) |
|---|---|---|
| `network-interconnect/patterns.md` | `/argo/` | `/argo-smart-routing/` |
| `artifacts/README.md` | `/artifacts/api/artifactfs/` | `/artifacts/guides/artifact-fs/` |
| `network-interconnect/README.md`, `gotchas.md` | `cni-locations-2026-01.pdf` | `cni-locations-05-may-2026.pdf` |
| `realtime-sfu/README.md` | `/workers-ai/realtimekit/` | `/realtime/realtimekit/` |
| `workers-vpc/README.md` | `/workers/tutorials/connect-to-postgres/` | `/workers/tutorials/postgres/` |
| `wrangler/gotchas.md` | `workers-sdk/tree/main/templates` | `cloudflare/templates` |
| `cron-triggers/gotchas.md` | `workers-sdk/.../fixtures/vitest-pool-workers-examples` | `/workers/testing/vitest-integration/` |
| `pages-functions/gotchas.md` | `cloudflare/pages-example-projects` | `/pages/framework-guides/` |

Notes on the three that aren't a straight path rename:

- **ArtifactFS** — the page still exists, just under `guides/` rather than `api/`. Found via `artifacts/llms-full.txt`.
- **CNI locations PDF** — the asset is versioned by date in its filename, so this link will rot again on the next revision. Current filename taken from `network-interconnect/llms-full.txt`. Linking the Get started page instead would be more durable if you'd prefer that.
- **Vitest fixtures / Pages examples** — both repo paths are gone with no successor repo, so I pointed them at the equivalent docs pages rather than dropping the bullets.

## Verification

Every replacement returns HTTP 200. After the change, a re-sweep of all 154 docs/GitHub links in `skills/cloudflare/` returns zero 404s (the only remaining non-200 is the intentional `https://github.com/user/repo.git` placeholder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)