### PR TITLE
Add installable Codex and Agent Plugins packaging

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "cloudflare",
+  "interface": {
+    "displayName": "Cloudflare"
+  },
+  "plugins": [
+    {
+      "name": "cloudflare",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "cloudflare",
       "source": {
-        "source": "local",
-        "path": "./"
+        "source": "url",
+        "url": "https://github.com/cloudflare/skills.git"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "cloudflare",
       "source": "./",
-      "description": "Skills for the Cloudflare developer platform"
+      "description": "Build, test, and deploy applications on Cloudflare with platform guidance Skills and the Cloudflare MCP server."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
   "name": "cloudflare",
-  "description": "Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance",
+  "description": "Build, test, and deploy applications on Cloudflare with platform guidance Skills and the Cloudflare MCP server.",
   "version": "1.0.0",
+  "mcpServers": "./.mcp.json",
   "author": {
     "name": "Cloudflare"
   }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,50 @@
+{
+  "name": "cloudflare",
+  "version": "1.0.0",
+  "description": "Build, test, and deploy applications on Cloudflare with platform guidance Skills and the Cloudflare MCP server.",
+  "author": {
+    "name": "Cloudflare",
+    "email": "support@cloudflare.com",
+    "url": "https://www.cloudflare.com/products/workers/"
+  },
+  "homepage": "https://developers.cloudflare.com/",
+  "repository": "https://github.com/cloudflare/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "cloudflare",
+    "workers",
+    "durable-objects",
+    "agents",
+    "mcp",
+    "wrangler",
+    "serverless",
+    "compute",
+    "storage",
+    "applications"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Cloudflare",
+    "shortDescription": "Cloudflare platform and MCP",
+    "longDescription": "Build, review, and operate on Cloudflare with guidance for Workers, Durable Objects, Agents SDK, Cloudflare One, Wrangler, web performance, Turnstile, and more, plus the Cloudflare Code Mode MCP server for live account, API, and documentation workflows.",
+    "developerName": "Cloudflare",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://developers.cloudflare.com/",
+    "privacyPolicyURL": "https://www.cloudflare.com/privacypolicy/",
+    "termsOfServiceURL": "https://www.cloudflare.com/website-terms/",
+    "defaultPrompt": [
+      "Build a Cloudflare Worker or agent with the right SDK and Wrangler setup",
+      "Review this Cloudflare project for production Workers best practices",
+      "Use Cloudflare skills and MCP to inspect or deploy this project"
+    ],
+    "brandColor": "#F6821F",
+    "composerIcon": "./logo.svg",
+    "logo": "./logo.svg",
+    "screenshots": []
+  }
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "cloudflare",
       "source": "./",
-      "description": "Skills for the Cloudflare developer platform"
+      "description": "Build, test, and deploy applications on Cloudflare with platform guidance Skills and the Cloudflare MCP server."
     }
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare",
   "version": "1.0.0",
-  "description": "Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance",
+  "description": "Build, test, and deploy applications on Cloudflare with platform guidance Skills and the Cloudflare MCP server.",
   "author": {
     "name": "Cloudflare",
     "email": "support@cloudflare.com",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,24 +1,8 @@
 {
   "mcpServers": {
-    "cloudflare-api": {
+    "cloudflare": {
       "type": "http",
       "url": "https://mcp.cloudflare.com/mcp"
-    },
-    "cloudflare-docs": {
-      "type": "http",
-      "url": "https://docs.mcp.cloudflare.com/mcp"
-    },
-    "cloudflare-bindings": {
-      "type": "http",
-      "url": "https://bindings.mcp.cloudflare.com/mcp"
-    },
-    "cloudflare-builds": {
-      "type": "http",
-      "url": "https://builds.mcp.cloudflare.com/mcp"
-    },
-    "cloudflare-observability": {
-      "type": "http",
-      "url": "https://observability.mcp.cloudflare.com/mcp"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,18 @@ A collection of [Agent Skills](https://www.anthropic.com/engineering/equipping-a
 
 ## Installing
 
-These skills work with any agent that supports the Agent Skills standard, including Claude Code, OpenCode, OpenAI Codex, and Pi.
+Use the native plugin where supported to install both Cloudflare guidance and the Cloudflare MCP server. Agents that only support the Agent Skills standard can install the skills separately.
+
+### Codex
+
+Install from the Cloudflare plugin marketplace:
+
+```sh
+codex plugin marketplace add cloudflare/skills
+codex plugin add cloudflare@cloudflare
+```
+
+Start a new Codex session after installation.
 
 ### Claude Code
 
@@ -76,15 +87,13 @@ Short, retrieval-first skills for [Cloudflare One](https://developers.cloudflare
 
 ## MCP Servers
 
-This plugin includes [Cloudflare's remote MCP servers](https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/) for enhanced functionality:
+This plugin includes Cloudflare's main [remote MCP server](https://developers.cloudflare.com/agents/model-context-protocol/cloudflare/servers-for-cloudflare/) for enhanced functionality:
 
 | Server | Purpose |
 |--------|---------|
-| cloudflare-api | Manage Cloudflare account resources, zones, and settings |
-| cloudflare-docs | Up-to-date Cloudflare documentation and reference |
-| cloudflare-bindings | Build Workers applications with storage, AI, and compute primitives |
-| cloudflare-builds | Manage and get insights into Workers builds |
-| cloudflare-observability | Debug and analyze application logs and analytics |
+| cloudflare | Access the Cloudflare API and current developer documentation through the Code Mode MCP server |
+
+Cloudflare also publishes product-specific MCP servers. This plugin intentionally bundles only the main `cloudflare` server.
 
 ## Resources
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "cloudflare": {
+      "type": "streamable-http",
+      "url": "https://mcp.cloudflare.com/mcp"
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "cloudflare",
+  "version": "1.0.0",
+  "description": "Build, test, and deploy applications on Cloudflare with platform guidance Skills and the Cloudflare MCP server.",
+  "author": {
+    "name": "Cloudflare",
+    "email": "support@cloudflare.com",
+    "url": "https://www.cloudflare.com/products/workers/"
+  },
+  "homepage": "https://developers.cloudflare.com/",
+  "repository": "https://github.com/cloudflare/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "cloudflare",
+    "workers",
+    "durable-objects",
+    "agents",
+    "mcp",
+    "wrangler",
+    "serverless",
+    "compute",
+    "storage",
+    "applications"
+  ]
+}

--- a/rules/workers.mdc
+++ b/rules/workers.mdc
@@ -22,7 +22,7 @@ STOP. Your knowledge of Cloudflare Workers APIs and limits may be outdated. Alwa
 ## Docs
 
 - https://developers.cloudflare.com/workers/
-- MCP: `https://docs.mcp.cloudflare.com/mcp`
+- Cloudflare MCP (`docs` tool): `https://mcp.cloudflare.com/mcp`
 
 For all limits and quotas, retrieve from the product's `/platform/limits/` page.
 

--- a/skills/cloudflare-email-service/SKILL.md
+++ b/skills/cloudflare-email-service/SKILL.md
@@ -15,7 +15,7 @@ Cloudflare Email Service lets you send transactional emails and route incoming e
 
 | Source | How to retrieve | Use for |
 |--------|----------------|---------|
-| Cloudflare docs | `cloudflare-docs` search tool or URL `https://developers.cloudflare.com/email-service/` | API reference, limits, pricing, latest features |
+| Cloudflare docs | Cloudflare MCP `docs` tool or URL `https://developers.cloudflare.com/email-service/` | API reference, limits, pricing, latest features |
 | REST API spec | `https://developers.cloudflare.com/api/resources/email_sending` | OpenAPI spec for the Email Sending REST API |
 | Workers types | `https://www.npmjs.com/package/@cloudflare/workers-types` | Type signatures, binding shapes |
 | Agents SDK docs | Fetch `docs/email.md` from `https://github.com/cloudflare/agents/tree/main/docs` | Email handling in Agents SDK |

--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -21,7 +21,7 @@ Fetch the **latest** information before citing specific numbers, API signatures,
 
 | Source | How to retrieve | Use for |
 |--------|----------------|---------|
-| Cloudflare docs | `cloudflare-docs` search tool or `https://developers.cloudflare.com/` | Limits, pricing, API reference, compatibility dates/flags |
+| Cloudflare docs | Cloudflare MCP `docs` tool or `https://developers.cloudflare.com/` | Limits, pricing, API reference, compatibility dates/flags |
 | Workers types | `npm pack @cloudflare/workers-types` or check `node_modules` | Type signatures, binding shapes, handler types |
 | Wrangler config schema | `node_modules/wrangler/config-schema.json` | Config fields, binding shapes, allowed values |
 | Product changelogs | `https://developers.cloudflare.com/changelog/` | Recent changes to limits, features, deprecations |

--- a/skills/cloudflare/references/pipelines/README.md
+++ b/skills/cloudflare/references/pipelines/README.md
@@ -4,7 +4,7 @@ Streaming ingest: receive events over HTTP/Workers/Logpush, transform with SQL, 
 
 ## Documentation
 
-This reference is a fast-start with verified code and gotchas. For limits, settings, full SQL syntax, and pricing, **retrieve the live docs** — use the `cloudflare-docs` MCP/search tool if available, otherwise `webfetch` the URL. Docs are source of truth over this file.
+This reference is a fast-start with verified code and gotchas. For limits, settings, full SQL syntax, and pricing, **retrieve the live docs** — use the Cloudflare MCP `docs` tool if available, otherwise `webfetch` the URL. Docs are source of truth over this file.
 
 | Topic | URL |
 |-------|-----|

--- a/skills/cloudflare/references/r2-data-catalog/README.md
+++ b/skills/cloudflare/references/r2-data-catalog/README.md
@@ -4,7 +4,7 @@ Managed Apache Iceberg REST catalog built into R2 buckets. No catalog servers to
 
 ## Documentation
 
-This reference is a fast-start with verified connection details and code. For limits, maintenance settings, engine config examples, and pricing, **retrieve the live docs** — use the `cloudflare-docs` MCP/search tool if available, otherwise `webfetch` the URL. Docs are source of truth over this file.
+This reference is a fast-start with verified connection details and code. For limits, maintenance settings, engine config examples, and pricing, **retrieve the live docs** — use the Cloudflare MCP `docs` tool if available, otherwise `webfetch` the URL. Docs are source of truth over this file.
 
 | Topic | URL |
 |-------|-----|

--- a/skills/cloudflare/references/r2-sql/README.md
+++ b/skills/cloudflare/references/r2-sql/README.md
@@ -4,7 +4,7 @@ Serverless, distributed, **read-only** query engine (Apache DataFusion) for Apac
 
 ## Documentation
 
-For full function lists, data types, and pricing, **retrieve the live docs** — use the `cloudflare-docs` MCP/search tool if available, otherwise `webfetch`.
+For full function lists, data types, and pricing, **retrieve the live docs** — use the Cloudflare MCP `docs` tool if available, otherwise `webfetch`.
 
 | Topic | URL |
 |-------|-----|


### PR DESCRIPTION
## Summary

- add native Codex plugin packaging and marketplace metadata
- add portable Agent Plugins 1.0 manifests
- bundle the main Cloudflare Code Mode MCP server
- update installation guidance and MCP references
- keep the package current with the stable and `@next` Sandbox skill split

This carries forward Angus Hawkings's work in #93 on top of current `main`.

## Codex install fix

The marketplace entry in #93 used a local `./` source for a plugin at the marketplace root. Codex accepted the marketplace but found no plugins:

```text
No marketplace plugins found.
Error: plugin `cloudflare` was not found in marketplace `cloudflare`
```

This branch uses a Git-backed root plugin source. Codex can discover and install that source shape.

## Validation

- parsed every JSON file with `jq empty`
- ran `git diff --check main...HEAD`
- reproduced the root-local-source failure with Codex CLI 0.150.1
- verified Codex CLI 0.150.1 discovers and installs the Git-backed root-plugin source shape

