### PR TITLE
fix: keep skill reference lists compatible with Agent Skills

### DIFF
--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: cloudflare
 description: Comprehensive Cloudflare platform skill covering Workers, Pages, storage (KV, D1, R2), AI (Workers AI, Vectorize, Agents SDK), feature flags (Flagship), networking (Tunnel, Spectrum), security (WAF, DDoS), and infrastructure-as-code (Terraform, Pulumi). Use for any Cloudflare development task. Biases towards retrieval from Cloudflare docs over pre-trained knowledge.
-references:
-  - workers
-  - pages
-  - d1
-  - durable-objects
-  - workers-ai
 ---
 
 # Cloudflare Platform Skill
@@ -14,6 +8,16 @@ references:
 Consolidated skill for building on the Cloudflare platform. Use decision trees below to find the right product, then load detailed references.
 
 Your knowledge of Cloudflare APIs, types, limits, and pricing may be outdated. **Prefer retrieval over pre-training** — the references in this skill are starting points, not source of truth.
+
+## References
+
+Load the relevant product reference as needed:
+
+- [Workers](references/workers/README.md)
+- [Pages](references/pages/README.md)
+- [D1](references/d1/README.md)
+- [Durable Objects](references/durable-objects/README.md)
+- [Workers AI](references/workers-ai/README.md)
 
 ## Retrieval Sources
 

--- a/skills/turnstile-spin/SKILL.md
+++ b/skills/turnstile-spin/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: turnstile-spin
 description: Set up Cloudflare Turnstile end-to-end in a project. Scan the codebase, create the widget via the Cloudflare API, embed it where user requests need bot verification (form submissions, SPA actions, API endpoints, download links, comment or vote submissions, etc.), wire canonical server-side siteverify in the customer's existing backend, validate, and persist the skill. Load this when a user asks to add Turnstile, set up CAPTCHA, protect a form or endpoint from bots, or fix a Turnstile integration. Mirrors developers.cloudflare.com/turnstile/spin.
-references:
-  - vanilla-html
-  - nextjs-app
-  - nextjs-pages
-  - astro
-  - sveltekit
-  - hugo
 ---
 
 # Turnstile Spin skill
@@ -17,6 +10,17 @@ Turns the prompt "set up Turnstile" into a working end-to-end integration: a wid
 You are the agent. Run the wizard below by invoking the scripts under `scripts/` and branching on their JSON output. The scripts hold the deterministic logic (API calls, retry/error handling); your job is orchestration, codebase reading, confirmation, and the frontend + backend edits.
 
 This file is the canonical machine-readable behavior. Product requirements come from the [Turnstile documentation](https://developers.cloudflare.com/turnstile/), and the hosted prompt must mirror this behavior.
+
+## References
+
+Load the reference matching the project's frontend framework:
+
+- [Vanilla HTML](references/vanilla-html.md)
+- [Next.js App Router](references/nextjs-app.md)
+- [Next.js Pages Router](references/nextjs-pages.md)
+- [Astro](references/astro.md)
+- [SvelteKit](references/sveltekit.md)
+- [Hugo](references/hugo.md)
 
 ## When to load this skill
 


### PR DESCRIPTION
## Summary

Move the `references` lists in the `cloudflare` and `turnstile-spin` skills from YAML frontmatter into Markdown links to the existing reference files.

The portable Agent Plugins package is already available at the repository root. However, `references` is not an allowed Agent Skills frontmatter field, so conforming consumers skip these two skills. The reference content, scripts, and existing instructions are unchanged.

## Verification

- All 13 skills pass frontmatter validation; all 11 relocated reference links exist.
- The modified package passed isolated add, info, update, and remove checks with Universal Agent Plugins 0.1.45 for Codex, Cursor, Kiro, Gemini CLI, OpenCode, Cline, Windsurf, and VS Code.
- All 13 skills were preserved; the unrelated test configuration survived removal.
- These are installation/materialization checks, not OAuth or Cloudflare tool-runtime tests.

No installer documentation or client-specific configuration changes.
