### PR TITLE
docs: recommend Zod 4.5.0 for Workers

### DIFF
--- a/skills/workers-best-practices/SKILL.md
+++ b/skills/workers-best-practices/SKILL.md
@@ -71,6 +71,7 @@ mkdir -p /tmp/workers-types-latest && \
 
 | Rule | Summary |
 |------|---------|
+| Zod version | Use [Zod 4.5.0 or later](https://github.com/colinhacks/zod/releases/tag/v4.5.0); when investigating high memory usage or OOMs, check and upgrade the installed version |
 | No global request state | Never store request-scoped data in module-level variables |
 | Floating promises | Every Promise must be `await`ed, `return`ed, `void`ed, or passed to `ctx.waitUntil()` |
 

--- a/skills/workers-best-practices/SKILL.md
+++ b/skills/workers-best-practices/SKILL.md
@@ -71,7 +71,6 @@ mkdir -p /tmp/workers-types-latest && \
 
 | Rule | Summary |
 |------|---------|
-| Zod version | Use [Zod 4.5.0 or later](https://github.com/colinhacks/zod/releases/tag/v4.5.0); when investigating high memory usage or OOMs, check and upgrade the installed version |
 | No global request state | Never store request-scoped data in module-level variables |
 | Floating promises | Every Promise must be `await`ed, `return`ed, `void`ed, or passed to `ctx.waitUntil()` |
 

--- a/skills/workers-best-practices/references/rules.md
+++ b/skills/workers-best-practices/references/rules.md
@@ -141,6 +141,10 @@ return new Response(text);
 
 **Retrieve**: streaming APIs at `/workers/runtime-apis/streams/`.
 
+### Use Zod 4.5.0 or later
+
+**Check**: Workers using Zod for runtime validation depend on [Zod 4.5.0 or later](https://github.com/colinhacks/zod/releases/tag/v4.5.0); older versions retain substantially more heap per schema, so check the installed version when investigating high memory usage or OOMs.
+
 ### Use waitUntil for work after the response
 
 `ctx.waitUntil()` performs background work (analytics, cache writes, webhooks) after the response is sent. Keeps response fast. 30-second time limit after response.


### PR DESCRIPTION
## Summary

Adds Workers guidance to use Zod 4.5.0 or later and to check the installed Zod version when investigating high memory usage or out-of-memory errors.

Zod 4.5 reduced retained heap per schema by up to 9.8x compared with Zod 4.4.3.

## Validation

- `git diff --check`
