### PR TITLE
Scope SDK installation and email onboarding to requested work

### DIFF
--- a/skills/agents-sdk/SKILL.md
+++ b/skills/agents-sdk/SKILL.md
@@ -70,21 +70,11 @@ The Agents SDK provides:
 - **Browser tools** (experimental) — CDP-powered browsing via `agents/browser`
 - **Think** (experimental) — Higher-level chat agent via `@cloudflare/think`
 
-## FIRST: Verify Installation
+## Dependencies when needed
 
-```bash
-npm ls agents  # Should show agents package
-```
+When implementing or running Agents SDK code, inspect the project's manifest and lockfile for `agents` and the packages needed by the requested feature. Restore declared dependencies with the existing lockfile if needed. Add missing dependencies only for the requested implementation, using the project's package manager and compatible version constraints; preserve existing versions unless the task requires an upgrade. Reviews and advice alone do not require installation.
 
-If not installed:
-```bash
-npm install agents
-```
-
-For chat agents:
-```bash
-npm install agents @cloudflare/ai-chat ai @ai-sdk/react
-```
+Chat implementations may also need `@cloudflare/ai-chat` and `ai`; add `@ai-sdk/react` only for a React client that uses it. Installation commands in references are examples to adapt to the project, not prerequisites for loading the skill.
 
 ## Wrangler Configuration
 

--- a/skills/cloudflare-email-service/SKILL.md
+++ b/skills/cloudflare-email-service/SKILL.md
@@ -20,14 +20,6 @@ Cloudflare Email Service lets you send transactional emails and route incoming e
 | Workers types | `https://www.npmjs.com/package/@cloudflare/workers-types` | Type signatures, binding shapes |
 | Agents SDK docs | Fetch `docs/email.md` from `https://github.com/cloudflare/agents/tree/main/docs` | Email handling in Agents SDK |
 
-## FIRST: Check Prerequisites
-
-Before writing any email code, verify the basics are in place:
-
-1. **Domain onboarded?** Run `npx wrangler email sending list` to see which domains have email sending enabled. If the domain isn't listed, run `npx wrangler email sending enable userdomain.com` or see [cli-and-mcp.md](references/cli-and-mcp.md) for full setup instructions.
-2. **Binding configured?** Look for `send_email` in `wrangler.jsonc` (for Workers)
-3. **postal-mime installed?** Run `npm ls postal-mime` (only needed for receiving/parsing emails)
-
 ## What Do You Need?
 
 Start here. Find your situation, then follow the link for full details.
@@ -42,9 +34,15 @@ Start here. Find your situation, then follow the link for full details.
 | **Set up Email Sending or Email Routing** | `wrangler email sending enable` / `wrangler email routing enable`, or Dashboard | [cli-and-mcp.md](references/cli-and-mcp.md) |
 | **Improve deliverability, avoid spam folders** | Authentication, content, compliance | [deliverability.md](references/deliverability.md) |
 
+## Prerequisites for the selected workflow
+
+- **Receiving/routing:** Use the routing configuration and `email()` handler guidance in [routing.md](references/routing.md). Receiving alone does not require Email Sending onboarding or a `send_email` binding. Check for a MIME parser such as `postal-mime` only if parsing is part of the implementation.
+- **Sending:** A sending domain must be onboarded before a live send. Check its account status when setting up or diagnosing sending, for example with `wrangler email sending list`. Enable a missing domain only when account setup is within the requested scope; see [cli-and-mcp.md](references/cli-and-mcp.md). For the Workers binding path, check `send_email`; for REST, use the API-token setup instead.
+- **Code-only work, reviews, or advice:** Account access and onboarding are not prerequisites. Implement the requested code and report any remaining deployment prerequisite. Add parser or other dependencies only when required, preserving the project's package manager, lockfile, and compatible versions. Use the existing project-local Wrangler runner for CLI commands.
+
 ## Quick Start — Workers Binding
 
-Add the binding to `wrangler.jsonc`, then call `env.EMAIL.send()`. The `from` domain must be onboarded via `npx wrangler email sending enable yourdomain.com`.
+For the sending binding path, add the binding to `wrangler.jsonc`, then call `env.EMAIL.send()`. Before a live send, the `from` domain must be onboarded; follow the sending prerequisites above.
 
 ```jsonc
 // wrangler.jsonc

--- a/skills/cloudflare-email-service/references/cli-and-mcp.md
+++ b/skills/cloudflare-email-service/references/cli-and-mcp.md
@@ -22,14 +22,25 @@ wrangler email sending
 
 ## Domain Setup
 
+Use this setup when configuring the requested account service. Receiving uses Email Routing; sending uses Email Sending. Code-only work and reviews do not require enabling either service. Use the project's existing Wrangler installation and package manager for the CLI examples.
+
 ### Via Dashboard
 
 1. Navigate to **Compute & AI** > **Email Service** > **Email Sending** (or **Email Routing**)
 2. Select **Onboard Domain** > choose domain > **Add records and onboard**
 
-This auto-adds SPF (TXT) and DKIM (CNAME/TXT) records. DNS usually propagates within 5-15 minutes.
+Email Sending onboarding auto-adds SPF (TXT) and DKIM (CNAME/TXT) records. Follow Email Routing's setup for its required records. DNS usually propagates within 5-15 minutes.
 
 ### Via CLI
+
+For receiving/routing setup:
+
+```bash
+npx wrangler email routing enable yourdomain.com
+npx wrangler email routing dns get yourdomain.com
+```
+
+For sending setup:
 
 ```bash
 npx wrangler email sending enable yourdomain.com
@@ -38,7 +49,7 @@ npx wrangler email sending dns get yourdomain.com   # Verify records
 
 ## Local Development
 
-Add `"remote": true` to send real emails during `wrangler dev`:
+When live sending is part of the requested test, add `"remote": true` to send real emails during `wrangler dev`:
 
 ```jsonc
 { "send_email": [{ "name": "EMAIL", "remote": true }] }

--- a/skills/wrangler/SKILL.md
+++ b/skills/wrangler/SKILL.md
@@ -17,19 +17,11 @@ Fetch the **latest** information before writing or reviewing Wrangler commands a
 | Wrangler config schema | `node_modules/wrangler/config-schema.json` | Config fields, binding shapes, allowed values |
 | Cloudflare docs | Search tool or `https://developers.cloudflare.com/workers/` | API reference, compatibility dates/flags |
 
-## FIRST: Check if Wrangler is installed, and if not, install it
+## Installation when needed
 
-Check if Wrangler is installed by running:
+For tasks that require running Wrangler, check the project's package manifest, lockfile, and scripts for its existing installation and version. Use the project's package manager and local command runner; a missing global `wrangler` command does not mean the project lacks Wrangler.
 
-```bash
-wrangler --version  # Requires v4.x+
-```
-
-If Wrangler is not installed, you should install it by running:
-
-```bash
-npm install -D wrangler@latest
-```
+Restore declared dependencies with the existing lockfile when needed. Add Wrangler as a development dependency only if the requested work requires it and it is not already declared. Preserve the project's package manager and version constraints; upgrade only when the task requires a newer version. Reviews and advice alone do not require installation.
 
 Wherever possible, you should use Wrangler instead of manually constructing API requests.
 
@@ -887,7 +879,7 @@ curl http://localhost:8787/__scheduled
 
 | Issue | Solution |
 |-------|----------|
-| `command not found: wrangler` | Install: `npm install -D wrangler` |
+| `command not found: wrangler` | Use the project-local runner; see Installation when needed before adding a dependency |
 | Auth errors | Run `wrangler login` |
 | Startup time limit exceeded | Run `wrangler check startup` to profile startup and generate CPU profiles |
 | Type errors after config change | Run `wrangler types` |


### PR DESCRIPTION
Loading Wrangler or Agents SDK guidance should not install dependencies for a review, and receiving email should not require Email Sending onboarding. Make setup conditional on the selected workflow, respect project package managers and existing versions, and distinguish receiving, sending, and code-only work.

A missing global Wrangler executable now points to the project-local runner before adding a dependency. Live email testing remains conditional on the requested test scope.

Validation: all three affected skills pass `quick_validate.py`; `git diff --check` passes. Reviewed the four-file diff. No live APIs, dependency changes, or executable changes.
