### PR TITLE
Trim Workers skill retrieval workflow

### DIFF
--- a/skills/workers-best-practices/SKILL.md
+++ b/skills/workers-best-practices/SKILL.md
@@ -1,32 +1,24 @@
 ---
 name: workers-best-practices
-description: Reviews and authors Cloudflare Workers code against production best practices. Load when writing new Workers, reviewing Worker code, configuring wrangler.jsonc, or checking for common Workers anti-patterns (streaming, floating promises, global state, secrets, bindings, observability). Biases towards retrieval from Cloudflare docs over pre-trained knowledge.
+description: Reviews and authors Cloudflare Workers code against production best practices. Load when writing new Workers, reviewing Worker code, configuring wrangler.jsonc, or checking for common Workers anti-patterns (streaming, floating promises, global state, secrets, bindings, observability).
 ---
 
-Your knowledge of Cloudflare Workers APIs, types, and configuration may be outdated. **Prefer retrieval over pre-training** for any Workers code task — writing or reviewing.
+Produce Workers code and reviews that are correct for the project's deployed runtime, safe under Workers platform constraints, and supported by proportionate evidence.
 
-## Retrieval Sources
+## Establish the Project Contract
 
-Fetch the **latest** versions before writing or reviewing Workers code. Do not rely on baked-in knowledge for API signatures, config fields, or binding shapes.
+Start with the project itself: its compatibility date and flags, pinned Wrangler and Workers types, generated environment types, configuration, package lockfile, tests, and established patterns. These define the contract an existing deployment must satisfy.
 
-| Source | How to retrieve | Use for |
-|--------|----------------|---------|
-| Workers best practices | Fetch `https://developers.cloudflare.com/workers/best-practices/workers-best-practices/` | Canonical rules, patterns, anti-patterns |
-| Workers types | See `references/review.md` for retrieval steps | API signatures, handler types, binding types |
-| Wrangler config schema | `node_modules/wrangler/config-schema.json` | Config fields, binding shapes, allowed values |
-| Cloudflare docs | Search tool or `https://developers.cloudflare.com/workers/` | API reference, compatibility dates/flags |
+Do not silently judge pinned code against a newer platform version. When proposing an upgrade, distinguish problems in the current contract from opportunities that require changing a dependency, compatibility date, or flag.
 
-## FIRST: Fetch Latest References
+Retrieve authoritative Cloudflare documentation or current published types when:
 
-Before reviewing or writing Workers code, retrieve the current best practices page and relevant type definitions. If the project's `node_modules` has an older version, **prefer the latest published version**.
+- the relevant API or configuration contract is absent, ambiguous, or disputed locally;
+- the task explicitly targets the latest platform behavior or a version upgrade;
+- a finding depends on behavior that may have changed since the pinned version; or
+- the consequence of guessing is material and local validation cannot settle it.
 
-```bash
-# Fetch latest workers types
-mkdir -p /tmp/workers-types-latest && \
-  npm pack @cloudflare/workers-types --pack-destination /tmp/workers-types-latest && \
-  tar -xzf /tmp/workers-types-latest/cloudflare-workers-types-*.tgz -C /tmp/workers-types-latest
-# Types at /tmp/workers-types-latest/package/index.d.ts
-```
+Use the narrowest useful source: the installed type declarations or Wrangler schema for pinned behavior, and the official Workers documentation or release information for current behavior. Record the applicable version, compatibility date, or flag when it affects the conclusion. Do not download packages merely to begin a routine task.
 
 ## Reference Documentation
 
@@ -100,16 +92,11 @@ mkdir -p /tmp/workers-types-latest && \
 | `implements` on platform base classes (instead of `extends`) | Legacy — loses `this.ctx`, `this.env`. Applies to DurableObject, WorkerEntrypoint, Workflow |
 | `env.X` inside platform base class | Should be `this.env.X` in classes extending DurableObject, WorkerEntrypoint, etc. |
 
-## Review Workflow
+## Apply Judgment
 
-1. **Retrieve** — fetch latest best practices page, workers types, and wrangler schema
-2. **Read full files** — not just diffs; context matters for binding access patterns
-3. **Check types** — binding access, handler signatures, no `any`, no unsafe casts (see `references/review.md`)
-4. **Check config** — compatibility_date, nodejs_compat, observability, secrets, binding-code consistency
-5. **Check patterns** — streaming, floating promises, global state, serialization boundaries
-6. **Check security** — crypto usage, secret handling, timing-safe comparisons, error handling
-7. **Validate with tools** — `npx tsc --noEmit`, lint for `no-floating-promises`
-8. **Reference rules** — see `references/rules.md` for each rule's correct pattern
+Inspect enough surrounding code and configuration to understand binding access, runtime boundaries, and deployment assumptions. Focus the review or implementation on risks relevant to the change: types and binding consistency, streaming and memory use, promise lifetime, cross-request state, serialization, secrets and cryptography, observability, and explicit error handling.
+
+Validate in proportion to the change. Prefer the project's own typecheck, tests, lint rules, and Wrangler validation. For a review, report only findings supported by code, local contracts, tool output, or a directly relevant official source. See `references/review.md` for deeper review guidance and `references/rules.md` for Workers-specific patterns.
 
 ## Scope
 
@@ -121,7 +108,7 @@ This skill covers Workers-specific best practices and code review. For related t
 
 ## Principles
 
-- **Be certain.** Retrieve before flagging. If unsure about an API, config field, or pattern, fetch the docs first.
+- **Be certain.** Verify uncertain API or configuration claims against the applicable local contract or authoritative documentation before flagging them.
 - **Provide evidence.** Reference line numbers, tool output, or docs links.
 - **Focus on what developers will copy.** Workers code in examples and docs gets pasted into production.
 - **Correctness over completeness.** A concise example that works beats a comprehensive one with errors.

--- a/skills/workers-best-practices/references/review.md
+++ b/skills/workers-best-practices/references/review.md
@@ -2,41 +2,23 @@
 
 How to review Workers code for type correctness, API usage, config validity, and best practices. This is self-contained — do not assume access to other skills.
 
-## Retrieval
+## Evidence Selection
 
-Prefer retrieval over pre-training. Types, config schemas, and APIs change with compatibility dates and new bindings.
+Types, config schemas, and APIs change with compatibility dates, flags, and dependency versions. For an existing project, use its pinned dependencies, generated types, configuration, lockfile, and tests as the primary contract. Do not automatically substitute the latest published package for the version the project deploys.
+
+Retrieve current official documentation or published types only when the local contract cannot answer the question, the task explicitly targets current behavior or an upgrade, or a material claim is sensitive to platform changes. State which version or compatibility setting the evidence applies to.
 
 ### Workers types
 
-Fetch the latest `@cloudflare/workers-types` before reviewing. The project may have an older version installed.
-
-```bash
-mkdir -p /tmp/workers-types-latest && \
-  npm pack @cloudflare/workers-types --pack-destination /tmp/workers-types-latest && \
-  tar -xzf /tmp/workers-types-latest/cloudflare-workers-types-*.tgz -C /tmp/workers-types-latest
-# Types are at /tmp/workers-types-latest/package/index.d.ts
-```
-
-Search this file for the specific type, class, or interface under review. Do not guess type names.
-
-Alternative: `npx wrangler types` generates a typed `Env` interface from the local wrangler config.
-
-Fallback: read `node_modules/@cloudflare/workers-types/index.d.ts`. Note the installed version.
+Use generated types from `wrangler types` when the project maintains them, or inspect its installed `@cloudflare/workers-types` declarations. Search for the specific type, class, or interface under review instead of guessing names. If neither is available and the exact signature matters, consult the official documentation or the package version appropriate to the task.
 
 ### Wrangler config schema
 
-The authoritative schema is bundled with wrangler as `config-schema.json` (JSON Schema draft-07).
-
-```bash
-# Read from local node_modules
-cat node_modules/wrangler/config-schema.json
-```
-
-Do not guess field names or structures — look them up.
+Use the schema bundled with the project's pinned Wrangler version when validating its existing configuration. Consult current official documentation when authoring against the latest Wrangler or planning an upgrade. Do not guess field names or structures when they can be checked locally.
 
 ### Cloudflare docs
 
-Use the Cloudflare docs search tool if available, or fetch from `https://developers.cloudflare.com/workers/`. The best practices page lives at `/workers/best-practices/workers-best-practices/`.
+Use official Cloudflare Workers documentation for platform behavior not established by local types, schemas, or tests. Retrieve the smallest relevant page rather than the full documentation set.
 
 ---
 
@@ -148,20 +130,15 @@ Valid: plain objects, arrays, strings, numbers, booleans, null, `ArrayBuffer`, `
 
 ---
 
-## Review Process
+## Review Scope
 
-1. **Retrieve** — fetch latest workers types, wrangler schema, and best practices page
-2. **Read full files** — not just diffs; context matters for binding access patterns
-3. **Categorize code** — determines what to check:
-   - **Illustrative** (concept demo, comments for most logic): verify correct API names and realistic signatures
-   - **Demonstrative** (functional snippet, would work in context): verify syntax, correct APIs, correct binding access
-   - **Executable** (standalone, runs without modification): verify compiles, runs, includes imports and config
-4. **Check types** — binding access pattern, handler signatures, no `any`, no unsafe casts
-5. **Check config** — compatibility_date, nodejs_compat, observability, secrets, binding-code consistency
-6. **Check patterns** — streaming, floating promises, global state, serialization boundaries
-7. **Check security** — crypto usage, secret handling, timing-safe comparisons, error handling
-8. **Validate with tools** — `npx tsc --noEmit`, lint for `no-floating-promises`
-9. **Assess risk** — HIGH (auth, crypto, bindings), MEDIUM (business logic, config), LOW (style, comments)
+Read enough context beyond the diff to understand bindings and deployment assumptions. Match the depth of review and validation to what the code claims to be:
+
+- **Illustrative** examples need correct API names and realistic signatures.
+- **Demonstrative** snippets should have valid syntax, APIs, and binding access in their stated context.
+- **Executable** projects should compile and include coherent imports, configuration, and bindings.
+
+Prioritize relevant risks rather than mechanically applying every check: handler and binding types, config-code consistency, streaming and promise lifetime, mutable global state, serialization boundaries, secrets and cryptography, and error handling. Use the project's available typecheck, tests, lint, and Wrangler validation where they add confidence. Assess severity from runtime impact and support each reported finding with evidence.
 
 ### Output format
 

--- a/skills/workers-best-practices/references/rules.md
+++ b/skills/workers-best-practices/references/rules.md
@@ -2,7 +2,7 @@
 
 Each rule has an imperative summary, what to check, the correct pattern, and an anti-pattern where applicable. Code examples are plain TypeScript — no MDX components.
 
-When a rule involves config fields or API signatures that may evolve, a **Retrieve** callout reminds you to check the latest docs or types before flagging. All doc paths are relative to `https://developers.cloudflare.com`.
+When a rule involves config fields or API signatures that may evolve, a **Retrieve** callout identifies an official source to consult when the project's local contract is insufficient or the task targets current behavior. All doc paths are relative to `https://developers.cloudflare.com`.
 
 ---
 
@@ -238,7 +238,7 @@ export class AuthService extends WorkerEntrypoint {
 const auth = await env.AUTH_SERVICE.verifyToken(token);
 ```
 
-**Retrieve**: verify `WorkerEntrypoint` import path and signature against latest `@cloudflare/workers-types`.
+**Retrieve**: verify the `WorkerEntrypoint` import path and signature against the types applicable to the project or requested target version.
 
 ### Use Hyperdrive for external database connections
 


### PR DESCRIPTION
## Summary

- make the project pinned runtime, types, configuration, and tests the primary contract
- retrieve official current docs or types only for ambiguous, material, or explicitly current-sensitive questions
- replace the fixed review checklist with risk-based, proportional validation
- remove the unconditional package download workflow while preserving Workers safety and correctness invariants

## Validation

- `git diff --check`
- parsed `skills/workers-best-practices/SKILL.md` frontmatter with Ruby YAML
- targeted search confirmed the unconditional latest-types download instructions were removed

No general test or Markdown-lint harness is present in this repository.