### PR TITLE
Fix skill frontmatter and optional web-perf setup

### DIFF
--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: cloudflare
 description: Choose Cloudflare products and look up platform references, including products without a dedicated skill. Use product-specific skills for their specialized workflows.
-references:
-  - workers
-  - pages
-  - d1
-  - durable-objects
-  - workers-ai
 ---
 
 # Cloudflare Platform Skill

--- a/skills/web-perf/SKILL.md
+++ b/skills/web-perf/SKILL.md
@@ -19,12 +19,12 @@ Your knowledge of web performance metrics, thresholds, and tooling APIs may be o
 
 Discover available browser and performance tools before starting. Use the capabilities available for the requested audit. If trace tools are unavailable, continue any useful source or network analysis and state which measurements could not be collected.
 
-If the user wants Chrome DevTools MCP setup, consult its [installation guide](https://github.com/ChromeDevTools/chrome-devtools-mcp#quick-start) and use an explicit package version. Only change MCP configuration when setup is within the user's authorized scope; otherwise ask first. For clients using `command` and `args`, an example server entry is:
+If the user wants Chrome DevTools MCP setup, consult its [installation guide](https://github.com/ChromeDevTools/chrome-devtools-mcp#quick-start) and use the latest package version. Only change MCP configuration when setup is within the user's authorized scope; otherwise ask first. For clients using `command` and `args`, an example server entry is:
 
 ```json
 "chrome-devtools": {
   "command": "npx",
-  "args": ["-y", "chrome-devtools-mcp@1.8.0"]
+  "args": ["-y", "chrome-devtools-mcp@latest"]
 }
 ```
 

--- a/skills/web-perf/SKILL.md
+++ b/skills/web-perf/SKILL.md
@@ -17,14 +17,14 @@ Your knowledge of web performance metrics, thresholds, and tooling APIs may be o
 
 ## FIRST: Verify MCP Tools Available
 
-**Run this before starting.** Try calling `navigate_page` or `performance_start_trace`. If unavailable, STOP—the chrome-devtools MCP server isn't configured.
+Discover available browser and performance tools before starting. Use the capabilities available for the requested audit. If trace tools are unavailable, continue any useful source or network analysis and state which measurements could not be collected.
 
-Ask the user to add this to their MCP config:
+If the user wants Chrome DevTools MCP setup, consult its [installation guide](https://github.com/ChromeDevTools/chrome-devtools-mcp#quick-start) and use an explicit package version. Only change MCP configuration when setup is within the user's authorized scope; otherwise ask first. For clients using `command` and `args`, an example server entry is:
 
 ```json
 "chrome-devtools": {
-  "type": "local",
-  "command": ["npx", "-y", "chrome-devtools-mcp@latest"]
+  "command": "npx",
+  "args": ["-y", "chrome-devtools-mcp@1.8.0"]
 }
 ```
 


### PR DESCRIPTION
Remove the unsupported `references` frontmatter key; the existing Markdown product index still exposes those references. Replace web-perf's mandatory setup stop with capability discovery and a useful partial-audit fallback, and use the documented command/args format while retaining `chrome-devtools-mcp@latest`.

Addresses the remaining frontmatter and web-perf setup portions of #85. Routing is covered by #116 and Wrangler size by merged PR #119; this PR does not duplicate those refactors or close the whole issue.

Validation: both skills pass the skill validator; `git diff --check` passes. Checked the setup format against the [upstream installation guide](https://github.com/ChromeDevTools/chrome-devtools-mcp#quick-start). No MCP configuration was changed and no browser server was installed.
