### PR TITLE
Document VS Code Copilot plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,13 @@ Install using the [plugin marketplace](https://code.claude.com/docs/en/discover-
 
 ### VS Code / GitHub Copilot
 
-Enable `chat.plugins.enabled` in VS Code, then add this repository to `chat.plugins.marketplaces` in your user settings:
+Install directly from this repository:
 
-```json
-{
-  "chat.plugins.marketplaces": ["cloudflare/skills"]
-}
-```
+1. Enable `chat.plugins.enabled` in VS Code settings.
+2. Open the Command Palette and run **Chat: Install Plugin From Source**.
+3. Enter `https://github.com/cloudflare/skills`.
 
-Preserve any marketplaces already listed. Open the Extensions view, search `@agentPlugins`, and install **cloudflare**. Alternatively, run **Chat: Install Plugin From Source** and enter `https://github.com/cloudflare/skills`.
-
-The repository already includes an Agent Plugins 1.0 manifest, `skills/`, and `mcp.json`; no VS Code-specific manifest is required. See [VS Code's agent plugin documentation](https://code.visualstudio.com/docs/agent-customization/agent-plugins) for installation and troubleshooting.
+For marketplace installation or troubleshooting, see [VS Code's agent plugin documentation](https://code.visualstudio.com/docs/agent-customization/agent-plugins).
 
 ### Cursor
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ Install using the [plugin marketplace](https://code.claude.com/docs/en/discover-
 /plugin install cloudflare@cloudflare
 ```
 
+### VS Code / GitHub Copilot
+
+Enable `chat.plugins.enabled` in VS Code, then add this repository to `chat.plugins.marketplaces` in your user settings:
+
+```json
+{
+  "chat.plugins.marketplaces": ["cloudflare/skills"]
+}
+```
+
+Preserve any marketplaces already listed. Open the Extensions view, search `@agentPlugins`, and install **cloudflare**. Alternatively, run **Chat: Install Plugin From Source** and enter `https://github.com/cloudflare/skills`.
+
+The repository already includes an Agent Plugins 1.0 manifest, `skills/`, and `mcp.json`; no VS Code-specific manifest is required. See [VS Code's agent plugin documentation](https://code.visualstudio.com/docs/agent-customization/agent-plugins) for installation and troubleshooting.
+
 ### Cursor
 
 Install from the Cursor Marketplace or add manually via **Settings > Rules > Add Rule > Remote Rule (Github)** with `cloudflare/skills`.


### PR DESCRIPTION
Document one direct-source installation path for VS Code / GitHub Copilot, with a link to the developer documentation for marketplace installation and troubleshooting. The existing Agent Plugins 1.0 package already has the recognized manifest, skills directory, and MCP configuration, so this only adds a short README section.

Fixes #32.

Validation: checked the instructions against [VS Code's current plugin documentation](https://code.visualstudio.com/docs/agent-customization/agent-plugins); validated `plugin.json` and `mcp.json` against their published schemas and checked marketplace source resolution. `git diff --check` passes. VS Code is not installed in the validation environment, so an interactive installation was not tested.
