### PR TITLE
Prefer Workers Cache for HTTP response caching

### DIFF
--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -54,7 +54,7 @@ Need to run code?
 
 ```
 Need storage?
-├─ Key-value (config, sessions, cache) → kv/
+├─ Key-value (config, sessions, application data) → kv/
 ├─ Relational SQL → d1/ (SQLite) or hyperdrive/ (existing Postgres/MySQL)
 ├─ Object/file storage (S3-compatible) → r2/
 ├─ Versioned file trees (repos, build outputs, checkpoints) → artifacts/
@@ -67,6 +67,8 @@ Need storage?
 ├─ Serverless SQL analytics over Iceberg tables → r2-sql/
 └─ Persistent cache (long-term retention) → cache-reserve/
 ```
+
+For eligible HTTP response caching, prefer [Workers Cache](https://developers.cloudflare.com/workers/cache/) over manual [Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/) or KV caching. Consult its [limitations](https://developers.cloudflare.com/workers/cache/limitations/) before choosing; use Cache API for explicit in-Worker cache operations, or [KV](https://developers.cloudflare.com/kv/concepts/how-kv-works/) when you need persistent application data with eventual consistency.
 
 ### "I need AI/ML"
 

--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -68,7 +68,7 @@ Need storage?
 └─ Persistent cache (long-term retention) → cache-reserve/
 ```
 
-For eligible HTTP response caching, prefer [Workers Cache](https://developers.cloudflare.com/workers/cache/) over manual [Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/) or KV caching. Consult its [limitations](https://developers.cloudflare.com/workers/cache/limitations/) before choosing; use Cache API for explicit in-Worker cache operations, or [KV](https://developers.cloudflare.com/kv/concepts/how-kv-works/) when you need persistent application data with eventual consistency.
+Prefer [Workers Cache](https://developers.cloudflare.com/workers/cache/) for caching, including [advanced patterns](https://developers.cloudflare.com/workers/cache/examples/) using cached inner entrypoints and programmatic invalidation. Choose [Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/) or KV caching only when a concrete requirement cannot be met by Workers Cache; check its [patterns](https://developers.cloudflare.com/workers/cache/examples/) and [limitations](https://developers.cloudflare.com/workers/cache/limitations/) first.
 
 ### "I need AI/ML"
 

--- a/skills/cloudflare/references/kv/patterns.md
+++ b/skills/cloudflare/references/kv/patterns.md
@@ -2,7 +2,7 @@
 
 ## Multi-Tier Caching
 
-For eligible HTTP response caching, prefer [Workers Cache](https://developers.cloudflare.com/workers/cache/). Use this pattern when you need a persistent application-data cache and can accept [KV's eventual consistency](https://developers.cloudflare.com/kv/concepts/how-kv-works/).
+For eligible HTTP response caching, prefer [Workers Cache](https://developers.cloudflare.com/workers/cache/). Use the KV caching pattern below when you need a persistent application-data cache and can accept [KV's eventual consistency](https://developers.cloudflare.com/kv/concepts/how-kv-works/).
 
 ```typescript
 // Memory → KV → Origin (3-tier cache)

--- a/skills/cloudflare/references/kv/patterns.md
+++ b/skills/cloudflare/references/kv/patterns.md
@@ -2,6 +2,8 @@
 
 ## Multi-Tier Caching
 
+For eligible HTTP response caching, prefer [Workers Cache](https://developers.cloudflare.com/workers/cache/). Use this pattern when you need a persistent application-data cache and can accept [KV's eventual consistency](https://developers.cloudflare.com/kv/concepts/how-kv-works/).
+
 ```typescript
 // Memory → KV → Origin (3-tier cache)
 const memoryCache = new Map<string, { data: any; expires: number }>();

--- a/skills/cloudflare/references/workers/api.md
+++ b/skills/cloudflare/references/workers/api.md
@@ -54,6 +54,8 @@ const key = env.API_KEY;
 
 ## Cache API
 
+Prefer [Workers Cache](https://developers.cloudflare.com/workers/cache/) for eligible HTTP response caching. Use the [Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/) below when explicit in-Worker cache operations are needed.
+
 ```typescript
 const cache = caches.default;
 let response = await cache.match(request);

--- a/skills/cloudflare/references/workers/api.md
+++ b/skills/cloudflare/references/workers/api.md
@@ -52,21 +52,9 @@ await env.MY_QUEUE.send({ timestamp: Date.now() });
 const key = env.API_KEY;
 ```
 
-## Cache API
+## Caching
 
-Prefer [Workers Cache](https://developers.cloudflare.com/workers/cache/) for eligible HTTP response caching. Use the [Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/) below when explicit in-Worker cache operations are needed.
-
-```typescript
-const cache = caches.default;
-let response = await cache.match(request);
-
-if (!response) {
-  response = await fetch(request);
-  response = new Response(response.body, response);
-  response.headers.set('Cache-Control', 'max-age=3600');
-  ctx.waitUntil(cache.put(request, response.clone()));  // Clone before caching
-}
-```
+Prefer [Workers Cache](https://developers.cloudflare.com/workers/cache/). Its [advanced patterns](https://developers.cloudflare.com/workers/cache/examples/) cover cached inner entrypoints, authenticated responses, and invalidation on writes; explicit cache control does not require switching to Cache API. Use the [Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/) only for a concrete requirement Workers Cache cannot meet after checking those patterns and its [limitations](https://developers.cloudflare.com/workers/cache/limitations/).
 
 ## HTMLRewriter
 


### PR DESCRIPTION
The skill routes caching requests toward KV and demonstrates Cache API usage without surfacing Workers Cache. Make [Workers Cache](https://developers.cloudflare.com/workers/cache/) the default, including for [advanced patterns](https://developers.cloudflare.com/workers/cache/examples/) such as cached inner entrypoints and invalidation on writes. Require a concrete unmet requirement before choosing Cache API or KV caching.

Replace the manual Cache API example with links to the official patterns and limitations, and add a short preference beside the KV caching example. Keep implementation details in developers.cloudflare.com. Three files changed, with a net reduction in lines.

Validation: skill validator and `git diff --check` passed; reviewed the official Workers Cache examples, configuration, and limitations.
