### PR TITLE
Route Workers AI guidance to current developer documentation

### DIFF
--- a/skills/cloudflare/references/workers-ai/README.md
+++ b/skills/cloudflare/references/workers-ai/README.md
@@ -1,197 +1,24 @@
 # Cloudflare Workers AI
 
-Expert guidance for Cloudflare Workers AI - serverless GPU-powered AI inference at the edge.
+Use Workers AI for managed model inference from Workers or an external service. Fetch the relevant documentation before choosing a model or writing integration code; model availability, schemas, capabilities, limits, and prices change independently.
 
-## Overview
+## Choose a model
 
-Workers AI provides:
-- 50+ pre-trained models (LLMs, embeddings, image generation, speech-to-text, translation)
-- Native Workers binding (no external API calls)
-- Pay-per-use pricing (neurons consumed per inference)
-- OpenAI-compatible REST API
-- Streaming support for text generation
-- Function calling with compatible models
+Start with the [model catalog](https://developers.cloudflare.com/workers-ai/models/) and open the selected model's page for its exact identifier, input/output schema, context window, and supported features. Compare candidates on the user's task, language, quality requirements, latency, and [current pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/). Evaluate with representative inputs rather than treating model size as a quality or cost ranking.
 
-**Architecture**: Inference runs on Cloudflare's GPU network. Models load on first request (cold start 1-3s), subsequent requests are faster.
+For tool use, streaming, or structured output, confirm support for the selected model and integration. For embeddings, check output dimensions and compatibility with the existing index; changing the model may require re-embedding stored documents, even if dimensions match.
 
-## Quick Start
+## Route by task
 
-```typescript
-interface Env {
-  AI: Ai;
-}
+- [configuration.md](./configuration.md): choose an integration, configure bindings and types, or set up development.
+- [api.md](./api.md): find inference schemas, streaming, tool calling, and structured output.
+- [patterns.md](./patterns.md): choose direct generation or RAG, and find integration examples.
+- [gotchas.md](./gotchas.md): diagnose binding, schema, limit, pricing, and SDK issues.
 
-export default {
-  async fetch(request: Request, env: Env) {
-    const response = await env.AI.run('@cf/meta/llama-3.1-8b-instruct', {
-      messages: [{ role: 'user', content: 'What is Cloudflare?' }]
-    });
-    return Response.json(response);
-  }
-};
-```
+If a topic is missing, use the [Workers AI documentation index](https://developers.cloudflare.com/workers-ai/llms.txt) to find its current page.
 
-```bash
-# Setup - add binding to wrangler.jsonc
-wrangler dev --remote  # Must use --remote for AI
-wrangler deploy
-```
+## Related products
 
-## Model Selection Decision Tree
-
-### Text Generation (Chat/Completion)
-
-**Quality Priority**:
-- **Best quality**: `@cf/meta/llama-3.1-70b-instruct` (expensive, ~2000 neurons)
-- **Balanced**: `@cf/meta/llama-3.1-8b-instruct` (good quality, ~200 neurons)
-- **Fastest/cheapest**: `@cf/mistral/mistral-7b-instruct-v0.1` (~50 neurons)
-
-**Function Calling**:
-- Use `@cf/meta/llama-3.1-8b-instruct` or `@cf/meta/llama-3.1-70b-instruct` (native tool support)
-
-**Code Generation**:
-- Use `@cf/deepseek-ai/deepseek-coder-6.7b-instruct` (specialized for code)
-
-### Embeddings (Semantic Search/RAG)
-
-**English text**:
-- **Best**: `@cf/baai/bge-large-en-v1.5` (1024 dims, highest quality)
-- **Balanced**: `@cf/baai/bge-base-en-v1.5` (768 dims, good quality)
-- **Fast**: `@cf/baai/bge-small-en-v1.5` (384 dims, lower quality but fast)
-
-**Multilingual**:
-- Use `@hf/sentence-transformers/paraphrase-multilingual-minilm-l12-v2`
-
-### Image Generation
-
-- **Stable Diffusion**: `@cf/stabilityai/stable-diffusion-xl-base-1.0` (~10,000 neurons)
-- **Portraits**: `@cf/lykon/dreamshaper-8-lcm` (optimized for faces)
-
-### Other Tasks
-
-- **Speech-to-text**: `@cf/openai/whisper`
-- **Translation**: `@cf/meta/m2m100-1.2b` (100 languages)
-- **Image classification**: `@cf/microsoft/resnet-50`
-
-## SDK Approach Decision Tree
-
-### Native Binding (Recommended)
-
-**When**: Building Workers/Pages with TypeScript  
-**Why**: Zero external dependencies, best performance, native types
-
-```typescript
-await env.AI.run(model, input);
-```
-
-### REST API
-
-**When**: External services, non-Workers environments, testing  
-**Why**: Standard HTTP, works anywhere
-
-```bash
-curl https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/ai/run/@cf/meta/llama-3.1-8b-instruct \
-  -H "Authorization: Bearer <API_TOKEN>" \
-  -d '{"messages":[{"role":"user","content":"Hello"}]}'
-```
-
-### Vercel AI SDK Integration
-
-**When**: Using Vercel AI SDK features (streaming UI, tool calling abstractions)  
-**Why**: Unified interface across providers
-
-```typescript
-import { openai } from '@ai-sdk/openai';
-
-const model = openai('model-name', {
-  baseURL: 'https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/ai/v1',
-  headers: { Authorization: 'Bearer <API_TOKEN>' }
-});
-```
-
-## RAG vs Direct Generation
-
-### Use RAG (Vectorize + Workers AI) When:
-- Answering questions about specific documents/data
-- Need factual accuracy from known corpus
-- Context exceeds model's window (>4K tokens)
-- Building knowledge base chat
-
-### Use Direct Generation When:
-- Creative writing, brainstorming
-- General knowledge questions
-- Small context fits in prompt (<4K tokens)
-- Cost optimization (RAG adds embedding + vector search costs)
-
-## Platform Limits
-
-| Limit | Free Tier | Paid Plans |
-|-------|-----------|------------|
-| Neurons/day | 10,000 | Pay per use |
-| Rate limit | Varies by model | Higher (contact support) |
-| Context window | Model dependent (2K-8K) | Same |
-| Streaming | ✅ Supported | ✅ Supported |
-| Function calling | ✅ Supported (select models) | ✅ Supported |
-
-**Pricing**: Free 10K neurons/day, then pay per neuron consumed (varies by model)
-
-## Common Tasks
-
-```typescript
-// Streaming text generation
-const stream = await env.AI.run(model, { messages, stream: true });
-for await (const chunk of stream) {
-  console.log(chunk.response);
-}
-
-// Embeddings for RAG
-const { data } = await env.AI.run('@cf/baai/bge-base-en-v1.5', {
-  text: ['Query text', 'Document 1', 'Document 2']
-});
-
-// Function calling
-const response = await env.AI.run('@cf/meta/llama-3.1-8b-instruct', {
-  messages: [{ role: 'user', content: 'What is the weather?' }],
-  tools: [{
-    type: 'function',
-    function: { name: 'getWeather', parameters: { ... } }
-  }]
-});
-```
-
-## Development Workflow
-
-```bash
-# Always use --remote for AI (local doesn't have models)
-wrangler dev --remote
-
-# Deploy to production
-wrangler deploy
-
-# View model catalog
-# https://developers.cloudflare.com/workers-ai/models/
-```
-
-## Reading Order
-
-**Start here**: Quick Start above → configuration.md (setup)
-
-**Common tasks**:
-- First time setup: configuration.md → Add binding + deploy
-- Choose model: Model Selection Decision Tree (above) → api.md
-- Build RAG: patterns.md → Vectorize integration
-- Optimize costs: Model Selection + gotchas.md (rate limits)
-- Debugging: gotchas.md → Common errors
-
-## In This Reference
-
-- [configuration.md](./configuration.md) - wrangler.jsonc setup, TypeScript types, bindings, environment variables
-- [api.md](./api.md) - env.AI.run(), streaming, function calling, REST API, response types
-- [patterns.md](./patterns.md) - RAG with Vectorize, prompt engineering, batching, error handling, caching
-- [gotchas.md](./gotchas.md) - Deprecated @cloudflare/ai package, rate limits, pricing, common errors
-
-## See Also
-
-- [vectorize](../vectorize/) - Vector database for RAG patterns
-- [ai-gateway](../ai-gateway/) - Caching, rate limiting, analytics for AI requests
-- [workers](../workers/) - Worker runtime and fetch handler patterns
+- [Vectorize](../vectorize/): vector storage and retrieval.
+- [AI Gateway](../ai-gateway/): inference analytics, caching, and request controls.
+- [Workers](../workers/): runtime and application hosting.

--- a/skills/cloudflare/references/workers-ai/api.md
+++ b/skills/cloudflare/references/workers-ai/api.md
@@ -1,112 +1,13 @@
-# Workers AI API Reference
+# Workers AI API
 
-## Core Method
+Fetch the selected model's page from the [model catalog](https://developers.cloudflare.com/workers-ai/models/) for request fields, output format, dimensions, and examples. Text, embeddings, images, audio, and translation do not share one response schema.
 
-```typescript
-const response = await env.AI.run(model, input);
-```
+| Task | Documentation |
+|------|---------------|
+| Invoke inference through a Worker binding | [Workers bindings](https://developers.cloudflare.com/workers-ai/configuration/bindings/) |
+| Invoke inference over HTTP | [REST API reference](https://developers.cloudflare.com/api/resources/ai/methods/run/) |
+| Stream text or use SDK abstractions | [Vercel AI SDK](https://developers.cloudflare.com/workers-ai/configuration/ai-sdk/), or the selected model's streaming example |
+| Define tools and handle tool results | [Function calling](https://developers.cloudflare.com/workers-ai/features/function-calling/) |
+| Request structured output | [JSON mode](https://developers.cloudflare.com/workers-ai/features/json-mode/) |
 
-## Text Generation
-
-```typescript
-const result = await env.AI.run('@cf/meta/llama-3.1-8b-instruct', {
-  messages: [
-    { role: 'system', content: 'You are helpful' },
-    { role: 'user', content: 'Hello' }
-  ],
-  temperature: 0.7,  // 0-1
-  max_tokens: 100
-});
-console.log(result.response);
-```
-
-**Streaming:**
-```typescript
-const stream = await env.AI.run(model, { messages, stream: true });
-return new Response(stream, { headers: { 'Content-Type': 'text/event-stream' } });
-```
-
-## Embeddings
-
-```typescript
-const result = await env.AI.run('@cf/baai/bge-base-en-v1.5', {
-  text: ['Query', 'Doc 1', 'Doc 2'] // Batch for efficiency
-});
-const [queryEmbed, doc1Embed, doc2Embed] = result.data; // 768-dim vectors
-```
-
-## Function Calling
-
-```typescript
-const tools = [{
-  type: 'function',
-  function: {
-    name: 'getWeather',
-    description: 'Get weather for location',
-    parameters: {
-      type: 'object',
-      properties: { location: { type: 'string' } },
-      required: ['location']
-    }
-  }
-}];
-
-const response = await env.AI.run(model, { messages, tools });
-if (response.tool_calls) {
-  const args = JSON.parse(response.tool_calls[0].function.arguments);
-  // Execute function, send result back
-}
-```
-
-## Image Generation
-
-```typescript
-const image = await env.AI.run('@cf/stabilityai/stable-diffusion-xl-base-1.0', {
-  prompt: 'Mountain sunset',
-  num_steps: 20,   // 1-20
-  guidance: 7.5    // 1-20
-});
-return new Response(image, { headers: { 'Content-Type': 'image/png' } });
-```
-
-## Speech Recognition
-
-```typescript
-const audioArray = Array.from(new Uint8Array(await request.arrayBuffer()));
-const result = await env.AI.run('@cf/openai/whisper', { audio: audioArray });
-console.log(result.text);
-```
-
-## Translation
-
-```typescript
-const result = await env.AI.run('@cf/meta/m2m100-1.2b', {
-  text: 'Hello',
-  source_lang: 'en',
-  target_lang: 'es'
-});
-console.log(result.translated_text);
-```
-
-## REST API
-
-```bash
-curl https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/run/@cf/meta/llama-3.1-8b-instruct \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"messages":[{"role":"user","content":"Hello"}]}'
-```
-
-## Error Codes
-
-| Code | Meaning | Fix |
-|------|---------|-----|
-| 7502 | Model not found | Check spelling |
-| 7504 | Validation failed | Verify input schema |
-| 7505 | Rate limited | Reduce rate or upgrade |
-| 7506 | Context exceeded | Reduce input size |
-
-## Performance Tips
-
-1. **Batch embeddings** - single request for multiple texts
-2. **Stream long responses** - reduce perceived latency
-3. **Accept cold starts** - first request ~1-3s, subsequent ~100-500ms
+Use the response and stream format documented for the chosen integration. Do not assume native binding streams are parsed objects or apply OpenAI response parsing to every model. Check the model's batching support and limits before combining inputs in one request.

--- a/skills/cloudflare/references/workers-ai/configuration.md
+++ b/skills/cloudflare/references/workers-ai/configuration.md
@@ -1,97 +1,16 @@
 # Workers AI Configuration
 
-## wrangler.jsonc
+Read the setup guide for the application's existing integration and installed SDK/Wrangler versions before adapting configuration.
 
-```jsonc
-{
-  "name": "my-ai-worker",
-  "main": "src/index.ts",
-  "compatibility_date": "2024-01-01",
-  "ai": {
-    "binding": "AI"
-  }
-}
-```
+| Task | Documentation |
+|------|---------------|
+| Create and develop a Worker with Workers AI | [Workers and Wrangler setup](https://developers.cloudflare.com/workers-ai/get-started/workers-wrangler/) |
+| Add an AI binding to an existing Worker | [Workers bindings](https://developers.cloudflare.com/workers-ai/configuration/bindings/) |
+| Generate environment and runtime types | [Workers TypeScript](https://developers.cloudflare.com/workers/languages/typescript/) |
+| Call inference from outside Workers | [REST API setup and authentication](https://developers.cloudflare.com/workers-ai/get-started/rest-api/) |
+| Use the Vercel AI SDK | [AI SDK integration](https://developers.cloudflare.com/workers-ai/configuration/ai-sdk/) |
+| Adapt an existing OpenAI SDK client | [OpenAI compatible endpoints](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/) |
 
-## TypeScript
+Prefer the native binding for a Worker that does not need an SDK abstraction; use REST for external services. Preserve an existing SDK integration when it meets the task, and check its supported endpoints and model features before substituting providers.
 
-```bash
-npm install --save-dev @cloudflare/workers-types
-```
-
-```typescript
-interface Env {
-  AI: Ai;
-}
-
-export default {
-  async fetch(request: Request, env: Env) {
-    const response = await env.AI.run('@cf/meta/llama-3.1-8b-instruct', {
-      messages: [{ role: 'user', content: 'Hello' }]
-    });
-    return Response.json(response);
-  }
-};
-```
-
-## Local Development
-
-```bash
-wrangler dev --remote  # Required for AI - no local inference
-```
-
-## REST API
-
-```typescript
-const response = await fetch(
-  `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/run/@cf/meta/llama-3.1-8b-instruct`,
-  {
-    method: 'POST',
-    headers: { 'Authorization': `Bearer ${API_TOKEN}` },
-    body: JSON.stringify({ messages: [{ role: 'user', content: 'Hello' }] })
-  }
-);
-```
-
-Create API token at: dash.cloudflare.com/profile/api-tokens (Workers AI - Read permission)
-
-## SDK Compatibility
-
-**OpenAI SDK:**
-```typescript
-import OpenAI from 'openai';
-const client = new OpenAI({
-  apiKey: env.CLOUDFLARE_API_TOKEN,
-  baseURL: `https://api.cloudflare.com/client/v4/accounts/${env.ACCOUNT_ID}/ai/v1`
-});
-```
-
-## Multi-Model Setup
-
-```typescript
-const MODELS = {
-  chat: '@cf/meta/llama-3.1-8b-instruct',
-  embed: '@cf/baai/bge-base-en-v1.5',
-  image: '@cf/stabilityai/stable-diffusion-xl-base-1.0'
-};
-```
-
-## RAG Setup (with Vectorize)
-
-```jsonc
-{
-  "ai": { "binding": "AI" },
-  "vectorize": {
-    "bindings": [{ "binding": "VECTORIZE", "index_name": "embeddings-index" }]
-  }
-}
-```
-
-## Troubleshooting
-
-| Error | Fix |
-|-------|-----|
-| `env.AI is undefined` | Check `ai` binding in wrangler.jsonc |
-| Local AI doesn't work | Use `wrangler dev --remote` |
-| Type 'Ai' not found | Install `@cloudflare/workers-types` |
-| @cloudflare/ai package error | Don't install - use native binding |
+Local Worker execution and local inference are different: Workers AI inference uses the Cloudflare account even during local development and consumes usage. Follow the current setup guide for development configuration; do not assume the entire Worker must run remotely.

--- a/skills/cloudflare/references/workers-ai/gotchas.md
+++ b/skills/cloudflare/references/workers-ai/gotchas.md
@@ -1,114 +1,15 @@
-# Workers AI Gotchas
+# Workers AI Troubleshooting
 
-## Critical: @cloudflare/ai is DEPRECATED
+Use the actual error, model identifier, integration, and installed versions to choose the relevant reference.
 
-```typescript
-// ❌ WRONG - Don't install @cloudflare/ai
-import Ai from '@cloudflare/ai';
+| Symptom or decision | Documentation and checks |
+|---------------------|--------------------------|
+| Missing binding or types | [Binding configuration](https://developers.cloudflare.com/workers-ai/configuration/bindings/) and [Workers TypeScript](https://developers.cloudflare.com/workers/languages/typescript/); check the environment being run |
+| Development inference fails | [Workers and Wrangler setup](https://developers.cloudflare.com/workers-ai/get-started/workers-wrangler/); check account access and binding setup |
+| Unknown model, invalid input, or unexpected response | Open the exact model in the [catalog](https://developers.cloudflare.com/workers-ai/models/); check its schema, context window, and feature support |
+| Inference error or retry decision | [Error codes and HTTP statuses](https://developers.cloudflare.com/workers-ai/platform/errors/) |
+| Throttling or concurrency planning | [Current limits](https://developers.cloudflare.com/workers-ai/platform/limits/) |
+| Usage or cost estimate | [Current pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/); use the selected model's billing units and expected workload |
+| Old SDK examples fail | [Native binding](https://developers.cloudflare.com/workers-ai/configuration/bindings/), [AI SDK](https://developers.cloudflare.com/workers-ai/configuration/ai-sdk/), or [OpenAI compatibility](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/), according to the integration |
 
-// ✅ CORRECT - Use native binding
-export default {
-  async fetch(request: Request, env: Env) {
-    await env.AI.run('@cf/meta/llama-3.1-8b-instruct', { messages: [...] });
-  }
-}
-```
-
-## Development
-
-### "AI inference doesn't work locally"
-```bash
-# ❌ Local AI doesn't work
-wrangler dev
-# ✅ Use remote
-wrangler dev --remote
-```
-
-### "env.AI is undefined"
-Add binding to wrangler.jsonc:
-```jsonc
-{ "ai": { "binding": "AI" } }
-```
-
-## API Responses
-
-### Embedding response shape varies
-```typescript
-// @cf/baai/bge-base-en-v1.5 returns: { data: [[0.1, 0.2, ...]] }
-const embedding = response.data[0]; // Get first element
-```
-
-### Stream returns ReadableStream
-```typescript
-const stream = await env.AI.run(model, { messages: [...], stream: true });
-for await (const chunk of stream) { console.log(chunk.response); }
-```
-
-## Rate Limits & Pricing
-
-| Model Type | Neurons/Request |
-|------------|-----------------|
-| Small text (7B) | ~50-200 |
-| Large text (70B) | ~500-2000 |
-| Embeddings | ~5-20 |
-| Image gen | ~10,000+ |
-
-**Free tier**: 10,000 neurons/day
-
-```typescript
-// ❌ EXPENSIVE - 70B model
-await env.AI.run('@cf/meta/llama-3.1-70b-instruct', ...);
-// ✅ CHEAPER - Use smallest that works
-await env.AI.run('@cf/meta/llama-3.1-8b-instruct', ...);
-```
-
-## Model-Specific
-
-### Function calling
-Only `@cf/meta/llama-3.1-*` and `mistral-7b-instruct-v0.2` support tools.
-
-### Empty response
-Check context limits (2K-8K tokens). Validate input structure.
-
-### Inconsistent responses
-Set `temperature: 0` for deterministic outputs.
-
-### Cold start latency
-First request: 1-3s. Use AI Gateway caching for frequent prompts.
-
-## TypeScript
-
-```typescript
-interface Env {
-  AI: Ai; // From @cloudflare/workers-types
-}
-
-interface TextGenerationResponse { response: string; }
-interface EmbeddingResponse { data: number[][]; shape: number[]; }
-```
-
-## Common Errors
-
-### 7502: Model not found
-Check exact model name at developers.cloudflare.com/workers-ai/models/
-
-### 7504: Input validation failed
-```typescript
-// Text gen requires messages array
-await env.AI.run('@cf/meta/llama-3.1-8b-instruct', {
-  messages: [{ role: 'user', content: 'Hello' }]  // ✅
-});
-
-// Embeddings require text
-await env.AI.run('@cf/baai/bge-base-en-v1.5', { text: 'Hello' });  // ✅
-```
-
-## Vercel AI SDK Integration
-
-```typescript
-import { openai } from '@ai-sdk/openai';
-const model = openai('gpt-3.5-turbo', {
-  baseURL: 'https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/ai/v1',
-  headers: { Authorization: 'Bearer <API_TOKEN>' }
-});
-```
+Do not copy an error-code mapping, per-request neuron estimate, or context-window range from another model or an older example. Measure latency for the intended workload rather than promising a fixed cold-start or inference time.

--- a/skills/cloudflare/references/workers-ai/patterns.md
+++ b/skills/cloudflare/references/workers-ai/patterns.md
@@ -1,120 +1,14 @@
 # Workers AI Patterns
 
-## RAG (Retrieval-Augmented Generation)
+Use direct generation when the supplied context fits the selected model and retrieval is unnecessary. Use RAG when answers need grounding in a document corpus or relevant passages must be selected from larger data; decide from the actual model context budget rather than a fixed token threshold.
 
-```typescript
-// 1. Embed query
-const embedding = await env.AI.run('@cf/baai/bge-base-en-v1.5', { text: query });
+| Task | Documentation |
+|------|---------------|
+| Build retrieval with Workers AI, Vectorize, and document storage | [RAG tutorial](https://developers.cloudflare.com/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai/) |
+| Stream responses or integrate tool calling in an SDK application | [AI SDK integration](https://developers.cloudflare.com/workers-ai/configuration/ai-sdk/) |
+| Constrain generated JSON | [JSON mode](https://developers.cloudflare.com/workers-ai/features/json-mode/) |
+| Add caching, retries, or model fallbacks | [Caching](https://developers.cloudflare.com/ai-gateway/features/caching/), [request handling](https://developers.cloudflare.com/ai-gateway/configuration/request-handling/), and [dynamic routing](https://developers.cloudflare.com/ai-gateway/features/dynamic-routing/) |
 
-// 2. Search vectors
-const results = await env.VECTORIZE.query(embedding.data[0], {
-  topK: 5, returnMetadata: true
-});
+Treat tutorial models as examples; select models using the [model criteria](./README.md#choose-a-model). For RAG, embed queries and documents with compatible models and match the index dimensions to the embeddings. Budget for retrieval and embedding work as well as generation.
 
-// 3. Build context
-const context = results.matches.map(m => m.metadata?.text).join('\n\n');
-
-// 4. Generate with context
-const response = await env.AI.run('@cf/meta/llama-3.1-8b-instruct', {
-  messages: [
-    { role: 'system', content: `Answer based on:\n\n${context}` },
-    { role: 'user', content: query }
-  ]
-});
-```
-
-## Streaming (SSE)
-
-```typescript
-const stream = await env.AI.run('@cf/meta/llama-3.1-8b-instruct', {
-  messages, stream: true
-});
-
-const { readable, writable } = new TransformStream();
-const writer = writable.getWriter();
-
-(async () => {
-  for await (const chunk of stream) {
-    await writer.write(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
-  }
-  await writer.write(new TextEncoder().encode('data: [DONE]\n\n'));
-  await writer.close();
-})();
-
-return new Response(readable, {
-  headers: { 'Content-Type': 'text/event-stream' }
-});
-```
-
-## Error Handling & Retry
-
-```typescript
-async function runWithRetry(env, model, input, maxRetries = 3) {
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
-    try {
-      return await env.AI.run(model, input);
-    } catch (error) {
-      if (error.message?.includes('7505') && attempt < maxRetries - 1) {
-        await new Promise(r => setTimeout(r, Math.pow(2, attempt) * 1000));
-        continue;
-      }
-      throw error;
-    }
-  }
-}
-```
-
-## Model Fallback
-
-```typescript
-try {
-  return await env.AI.run('@cf/meta/llama-3.1-70b-instruct', { messages });
-} catch {
-  return await env.AI.run('@cf/meta/llama-3.1-8b-instruct', { messages });
-}
-```
-
-## Prompt Patterns
-
-```typescript
-// System prompts
-const PROMPTS = {
-  json: 'Respond with valid JSON only.',
-  concise: 'Keep responses brief.',
-  cot: 'Think step by step before answering.'
-};
-
-// Few-shot
-messages: [
-  { role: 'system', content: 'Extract as JSON' },
-  { role: 'user', content: 'John bought 3 apples for $5' },
-  { role: 'assistant', content: '{"name":"John","item":"apples","qty":3}' },
-  { role: 'user', content: actualInput }
-]
-```
-
-## Parallel Execution
-
-```typescript
-const [sentiment, summary, embedding] = await Promise.all([
-  env.AI.run('@cf/mistral/mistral-7b-instruct-v0.1', { messages: sentimentPrompt }),
-  env.AI.run('@cf/meta/llama-3.1-8b-instruct', { messages: summaryPrompt }),
-  env.AI.run('@cf/baai/bge-base-en-v1.5', { text })
-]);
-```
-
-## Cost Optimization
-
-| Task | Model | Neurons |
-|------|-------|---------|
-| Classify | `@cf/mistral/mistral-7b-instruct-v0.1` | ~50 |
-| Chat | `@cf/meta/llama-3.1-8b-instruct` | ~200 |
-| Complex | `@cf/meta/llama-3.1-70b-instruct` | ~2000 |
-| Embed | `@cf/baai/bge-base-en-v1.5` | ~10 |
-
-```typescript
-// Batch embeddings
-const response = await env.AI.run('@cf/baai/bge-base-en-v1.5', {
-  text: textsArray // Process multiple at once
-});
-```
+Before adding a fallback model, verify that it can satisfy the same schema, context, and tool requirements. For retry decisions, distinguish transient failures from invalid inputs or configuration using the [error and limit references](./gotchas.md).


### PR DESCRIPTION
The Workers AI references duplicate model rankings, neuron estimates, API recipes, and error tables that have drifted from current docs. They also require `wrangler dev --remote` even though the current setup supports local Worker execution with account-backed inference.

Replace the five reference files with task-specific links to maintained Cloudflare documentation, following #122. Keep model-selection criteria, embedding/index compatibility, direct generation versus RAG, integration choices, and the distinction between local execution and remote inference. Existing reference paths remain available to callers.

Validation: fetched the linked documentation and checked coverage for the removed examples; checked relative links; skill validation and `git diff --check` pass. Documentation only: 640 lines reduced to 82 across five files.
