### PR TITLE
Route browser automation guidance to current Browser Run docs

### DIFF
--- a/skills/cloudflare/references/browser-rendering/README.md
+++ b/skills/cloudflare/references/browser-rendering/README.md
@@ -1,78 +1,18 @@
-# Cloudflare Browser Rendering Skill Reference
+# Browser Run (formerly Browser Rendering)
 
-**Description**: Expert knowledge for Cloudflare Browser Rendering - control headless Chrome on Cloudflare's global network for browser automation, screenshots, PDFs, web scraping, testing, and content generation.
+Use Browser Run for screenshots, PDFs, rendered content extraction, and browser automation. Read the relevant current documentation before implementing; use the [documentation index](https://developers.cloudflare.com/browser-run/llms.txt) to discover additional guides.
 
-**When to use**: Any task involving Cloudflare Browser Rendering including: taking screenshots, generating PDFs, web scraping, browser automation, testing web applications, extracting structured data, capturing page metrics, or automating browser interactions.
+Choose the integration by the work and runtime:
 
-## Decision Tree
+- For a self-contained screenshot, PDF, or extraction, start with Quick Actions. They are available through REST and Workers bindings; check the chosen action's supported interface.
+- For multi-step interactions or persistent state, use browser sessions. In Workers, use Cloudflare's Puppeteer or Playwright package; from external scripts or CI, use the CDP integration.
+- When adapting existing automation, preserve its library where supported and check installed versions against the corresponding guide.
 
-### REST API vs Workers Bindings
+Read only the reference needed for the task:
 
-**Use REST API when:**
-- One-off, stateless tasks (screenshot, PDF, content fetch)
-- No Workers infrastructure yet
-- Simple integrations from external services
-- Need quick prototyping without deployment
-
-**Use Workers Bindings when:**
-- Complex browser automation workflows
-- Need session reuse for performance
-- Multiple page interactions per request
-- Custom scripting and logic required
-- Building production applications
-
-### Puppeteer vs Playwright
-
-| Feature | Puppeteer | Playwright |
-|---------|-----------|------------|
-| API Style | Chrome DevTools Protocol | High-level abstractions |
-| Selectors | CSS, XPath | CSS, text, role, test-id |
-| Best for | Advanced control, CDP access | Quick automation, testing |
-| Learning curve | Steeper | Gentler |
-
-**Use Puppeteer:** Need CDP protocol access, Chrome-specific features, migration from existing Puppeteer code
-**Use Playwright:** Modern selector APIs, cross-browser patterns, faster development
-
-## Tier Limits Summary
-
-| Limit | Free Tier | Paid Tier |
-|-------|-----------|-----------|
-| Daily browser time | 10 minutes | Unlimited* |
-| Concurrent sessions | 3 | 30 |
-| Requests per minute | 6 | 180 |
-
-*Subject to fair-use policy. See [gotchas.md](gotchas.md) for details.
-
-## Reading Order
-
-**New to Browser Rendering:**
-1. [configuration.md](configuration.md) - Setup and deployment
-2. [patterns.md](patterns.md) - Common use cases with examples
-3. [api.md](api.md) - API reference
-4. [gotchas.md](gotchas.md) - Avoid common pitfalls
-
-**Specific task:**
-- **Setup/deployment** → [configuration.md](configuration.md)
-- **API reference/endpoints** → [api.md](api.md)
-- **Example code/patterns** → [patterns.md](patterns.md)
-- **Debugging/troubleshooting** → [gotchas.md](gotchas.md)
-
-**REST API users:**
-- Start with [api.md](api.md) REST API section
-- Check [gotchas.md](gotchas.md) for rate limits
-
-**Workers users:**
-- Start with [configuration.md](configuration.md)
-- Review [patterns.md](patterns.md) for session management
-- Reference [api.md](api.md) for Workers Bindings
-
-## In This Reference
-
-- **[configuration.md](configuration.md)** - Setup, deployment, wrangler config, compatibility
-- **[api.md](api.md)** - REST API endpoints + Workers Bindings (Puppeteer/Playwright)
-- **[patterns.md](patterns.md)** - Common patterns, use cases, real examples
-- **[gotchas.md](gotchas.md)** - Troubleshooting, best practices, tier limits, common errors
-
-## See Also
-
-- [Cloudflare Docs](https://developers.cloudflare.com/browser-rendering/)
+| Task | Reference |
+|------|-----------|
+| Set up bindings, dependencies, or development | [configuration.md](configuration.md) |
+| Select an endpoint or browser client API | [api.md](api.md) |
+| Implement a workflow or manage reusable sessions | [patterns.md](patterns.md) |
+| Diagnose failures or plan capacity and cost | [gotchas.md](gotchas.md) |

--- a/skills/cloudflare/references/browser-rendering/api.md
+++ b/skills/cloudflare/references/browser-rendering/api.md
@@ -1,108 +1,12 @@
-# Browser Rendering API
+# Browser Run APIs
 
-## REST API
+Read the guide for the chosen interface for request schemas, return types, authentication, and supported options. Keep Quick Actions and browser session APIs distinct when adapting examples.
 
-**Base:** `https://api.cloudflare.com/client/v4/accounts/{accountId}/browser-rendering`  
-**Auth:** `Authorization: Bearer <token>` (Browser Rendering - Edit permission)
+| Task | Documentation |
+|------|---------------|
+| Screenshots, PDFs, HTML, scraping, or structured extraction | [Quick Actions](https://developers.cloudflare.com/browser-run/quick-actions/) — links to each action's request options and examples for REST or Workers bindings |
+| Automate a browser in Workers with Puppeteer | [Puppeteer](https://developers.cloudflare.com/browser-run/puppeteer/) — Cloudflare package, browser operations, and session APIs |
+| Automate a browser in Workers with Playwright | [Playwright](https://developers.cloudflare.com/browser-run/playwright/) — Cloudflare package, locators, storage state, and tracing |
+| Control a remote browser from an external runtime | [CDP](https://developers.cloudflare.com/browser-run/cdp/) — session endpoints and links to Puppeteer, Playwright, and other clients |
 
-### Endpoints
-
-| Endpoint | Description | Key Options |
-|----------|-------------|-------------|
-| `/content` | Get rendered HTML | `url`, `waitUntil` |
-| `/screenshot` | Capture image | `screenshotOptions: {type, fullPage, clip}` |
-| `/pdf` | Generate PDF | `pdfOptions: {format, landscape, margin}` |
-| `/snapshot` | HTML + inlined resources | `url` |
-| `/scrape` | Extract by selectors | `selectors: ["h1", ".price"]` |
-| `/json` | AI-structured extraction | `schema: {name: "string", price: "number"}` |
-| `/links` | Get all links | `url` |
-| `/markdown` | Convert to markdown | `url` |
-
-```bash
-curl -X POST '.../browser-rendering/screenshot' \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"url":"https://example.com","screenshotOptions":{"fullPage":true}}'
-```
-
-## Workers Binding
-
-```jsonc
-// wrangler.jsonc
-{ "browser": { "binding": "MYBROWSER" } }
-```
-
-## Puppeteer
-
-```typescript
-import puppeteer from "@cloudflare/puppeteer";
-
-const browser = await puppeteer.launch(env.MYBROWSER, { keep_alive: 600000 });
-const page = await browser.newPage();
-await page.goto('https://example.com', { waitUntil: 'networkidle0' });
-
-// Content
-const html = await page.content();
-const title = await page.title();
-
-// Screenshot/PDF
-await page.screenshot({ fullPage: true, type: 'png' });
-await page.pdf({ format: 'A4', printBackground: true });
-
-// Interaction
-await page.click('#button');
-await page.type('#input', 'text');
-await page.evaluate(() => document.querySelector('h1')?.textContent);
-
-// Session management
-const sessions = await puppeteer.sessions(env.MYBROWSER);
-const limits = await puppeteer.limits(env.MYBROWSER);
-
-await browser.close();
-```
-
-## Playwright
-
-```typescript
-import { launch, connect } from "@cloudflare/playwright";
-
-const browser = await launch(env.MYBROWSER, { keep_alive: 600000 });
-const page = await browser.newPage();
-
-await page.goto('https://example.com', { waitUntil: 'networkidle' });
-
-// Modern selectors
-await page.locator('.button').click();
-await page.getByText('Submit').click();
-await page.getByTestId('search').fill('query');
-
-// Context for isolation
-const context = await browser.newContext({
-  viewport: { width: 1920, height: 1080 },
-  userAgent: 'custom'
-});
-
-await browser.close();
-```
-
-## Session Management
-
-```typescript
-// List sessions
-await puppeteer.sessions(env.MYBROWSER);
-
-// Connect to existing
-await puppeteer.connect(env.MYBROWSER, sessionId);
-
-// Check limits
-await puppeteer.limits(env.MYBROWSER);
-// { remaining: ms, total: ms, concurrent: n }
-```
-
-## Key Options
-
-| Option | Values |
-|--------|--------|
-| `waitUntil` | `load`, `domcontentloaded`, `networkidle0`, `networkidle2` |
-| `keep_alive` | Max 600000ms (10 min) |
-| `screenshot.type` | `png`, `jpeg` |
-| `pdf.format` | `A4`, `Letter`, `Legal` |
+The product rename does not imply a rename of API paths or token permissions. Use the identifiers shown in the selected guide.

--- a/skills/cloudflare/references/browser-rendering/configuration.md
+++ b/skills/cloudflare/references/browser-rendering/configuration.md
@@ -1,78 +1,12 @@
-# Configuration & Setup
+# Browser Run Configuration
 
-## Installation
+Check the project's runtime, installed client and Wrangler versions, and compatibility date before adapting setup instructions. Cloudflare's packages for Workers and standard clients connecting over CDP have different setup requirements.
 
-```bash
-npm install @cloudflare/puppeteer  # or @cloudflare/playwright
-```
+| Task | Documentation |
+|------|---------------|
+| Start a project or configure REST authentication | [Get started](https://developers.cloudflare.com/browser-run/get-started/) — Quick Actions and browser session setup |
+| Configure a Worker or choose a development mode | [Wrangler reference](https://developers.cloudflare.com/browser-run/reference/wrangler/) — browser bindings, compatibility requirements, and local/remote development |
+| Install or update a Workers browser client | [Puppeteer](https://developers.cloudflare.com/browser-run/puppeteer/) or [Playwright](https://developers.cloudflare.com/browser-run/playwright/) — package-specific setup and supported versions |
+| Connect from a script, server, or CI outside Workers | [CDP](https://developers.cloudflare.com/browser-run/cdp/) — authentication and client integration guides |
 
-**Use Cloudflare packages** - standard `puppeteer`/`playwright` won't work in Workers.
-
-## wrangler.json
-
-```json
-{
-  "name": "browser-worker",
-  "main": "src/index.ts",
-  "compatibility_date": "2025-01-01",
-  "compatibility_flags": ["nodejs_compat"],
-  "browser": {
-    "binding": "MYBROWSER"
-  }
-}
-```
-
-**Required:** `nodejs_compat` flag and `browser.binding`.
-
-## TypeScript
-
-```typescript
-interface Env {
-  MYBROWSER: Fetcher;
-}
-
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    // ...
-  }
-} satisfies ExportedHandler<Env>;
-```
-
-## Development
-
-```bash
-wrangler dev --remote  # --remote required for browser binding
-```
-
-**Local mode does NOT support Browser Rendering** - must use `--remote`.
-
-## REST API
-
-No wrangler config needed. Get API token with "Browser Rendering - Edit" permission.
-
-```bash
-curl -X POST \
-  'https://api.cloudflare.com/client/v4/accounts/{accountId}/browser-rendering/screenshot' \
-  -H 'Authorization: Bearer TOKEN' \
-  -d '{"url": "https://example.com"}' --output screenshot.png
-```
-
-## Requirements
-
-| Requirement | Value |
-|-------------|-------|
-| Node.js compatibility | `nodejs_compat` flag |
-| Compatibility date | 2023-03-01+ |
-| Module format | ES modules only |
-| Browser | Chromium 119+ (no Firefox/Safari) |
-
-**Not supported:** WebGL, WebRTC, extensions, `file://` protocol, Service Worker syntax.
-
-## Troubleshooting
-
-| Error | Solution |
-|-------|----------|
-| `MYBROWSER is undefined` | Use `wrangler dev --remote` |
-| `nodejs_compat not enabled` | Add to `compatibility_flags` |
-| `Module not found` | `npm install @cloudflare/puppeteer` |
-| `Browser Rendering not available` | Enable in dashboard |
+Development support depends on the selected interface. Follow its current guidance rather than applying one remote-mode requirement to all Browser Run workflows.

--- a/skills/cloudflare/references/browser-rendering/gotchas.md
+++ b/skills/cloudflare/references/browser-rendering/gotchas.md
@@ -7,6 +7,8 @@ Identify the integration and observed failure before changing timeouts or concur
 | Quotas, launch rates, concurrency, and session timeouts | [Limits](https://developers.cloudflare.com/browser-run/limits/) — check the current plan and integration-specific limits |
 | Browser hours and concurrent-browser charges | [Pricing](https://developers.cloudflare.com/browser-run/pricing/) — distinguish Quick Actions from browser sessions |
 | Missing bindings, action failures, or unsupported behavior | [FAQ](https://developers.cloudflare.com/browser-run/faq/) — diagnose the reported error and runtime constraints |
+| Puppeteer page evaluation cannot access outer variables | [JavaScript execution](https://pptr.dev/guides/javascript-execution) — browser execution context, passing arguments, and returned values |
+| Block resources or handle intercepted Puppeteer requests | [Request interception](https://pptr.dev/guides/network-interception) — continue, respond, or abort requests and avoid duplicate handling |
 | Unexpected disconnects or session loss | [Browser close reasons](https://developers.cloudflare.com/browser-run/reference/browser-close-reasons/) — inspect the recorded close reason before choosing recovery |
 | Development or compatibility failures | [Wrangler reference](https://developers.cloudflare.com/browser-run/reference/wrangler/) — verify binding configuration and interface-specific development support |
 

--- a/skills/cloudflare/references/browser-rendering/gotchas.md
+++ b/skills/cloudflare/references/browser-rendering/gotchas.md
@@ -1,88 +1,13 @@
-# Browser Rendering Gotchas
+# Browser Run Troubleshooting
 
-## Tier Limits
+Identify the integration and observed failure before changing timeouts or concurrency. A request-rate limit, exhausted browser time, and a closed session require different responses.
 
-| Limit | Free | Paid |
-|-------|------|------|
-| Daily browser time | 10 min | Unlimited* |
-| Concurrent sessions | 3 | 30 |
-| Requests/minute | 6 | 180 |
-| Session keep-alive | 10 min max | 10 min max |
+| Concern | Documentation |
+|---------|---------------|
+| Quotas, launch rates, concurrency, and session timeouts | [Limits](https://developers.cloudflare.com/browser-run/limits/) — check the current plan and integration-specific limits |
+| Browser hours and concurrent-browser charges | [Pricing](https://developers.cloudflare.com/browser-run/pricing/) — distinguish Quick Actions from browser sessions |
+| Missing bindings, action failures, or unsupported behavior | [FAQ](https://developers.cloudflare.com/browser-run/faq/) — diagnose the reported error and runtime constraints |
+| Unexpected disconnects or session loss | [Browser close reasons](https://developers.cloudflare.com/browser-run/reference/browser-close-reasons/) — inspect the recorded close reason before choosing recovery |
+| Development or compatibility failures | [Wrangler reference](https://developers.cloudflare.com/browser-run/reference/wrangler/) — verify binding configuration and interface-specific development support |
 
-*Subject to fair-use policy.
-
-**Check quota:**
-```typescript
-const limits = await puppeteer.limits(env.MYBROWSER);
-// { remaining: 540000, total: 600000, concurrent: 2 }
-```
-
-## Always Close Browsers
-
-```typescript
-const browser = await puppeteer.launch(env.MYBROWSER);
-try {
-  const page = await browser.newPage();
-  await page.goto("https://example.com");
-  return new Response(await page.content());
-} finally {
-  await browser.close(); // ALWAYS in finally
-}
-```
-
-**Workers vs REST:** REST auto-closes after timeout. Workers must call `close()` or session stays open until `keep_alive` expires.
-
-## Optimize Concurrency
-
-```typescript
-// ❌ 3 sessions (hits free tier limit)
-const browser1 = await puppeteer.launch(env.MYBROWSER);
-const browser2 = await puppeteer.launch(env.MYBROWSER);
-
-// ✅ 1 session, multiple pages
-const browser = await puppeteer.launch(env.MYBROWSER);
-const page1 = await browser.newPage();
-const page2 = await browser.newPage();
-```
-
-## Common Errors
-
-| Error | Cause | Fix |
-|-------|-------|-----|
-| Session limit exceeded | Too many concurrent | Close unused browsers, use pages not browsers |
-| Page navigation timeout | Slow page or `networkidle` on busy page | Increase timeout, use `waitUntil: "load"` |
-| Session not found | Expired session | Catch error, launch new session |
-| Evaluation failed | DOM element missing | Use `?.` optional chaining |
-| Protocol error: Target closed | Page closed during operation | Await all ops before closing |
-
-## page.evaluate() Gotchas
-
-```typescript
-// ❌ Outer scope not available
-const selector = "h1";
-await page.evaluate(() => document.querySelector(selector));
-
-// ✅ Pass as argument
-await page.evaluate((sel) => document.querySelector(sel)?.textContent, selector);
-```
-
-## Performance
-
-**waitUntil options (fastest to slowest):**
-1. `domcontentloaded` - DOM ready
-2. `load` - load event (default)
-3. `networkidle0` - no network for 500ms
-
-**Block unnecessary resources:**
-```typescript
-await page.setRequestInterception(true);
-page.on("request", (req) => {
-  if (["image", "stylesheet", "font"].includes(req.resourceType())) {
-    req.abort();
-  } else {
-    req.continue();
-  }
-});
-```
-
-**Session reuse:** Cold start ~1-2s, warm connect ~100-200ms. Store sessionId in KV for reuse.
+Before increasing concurrency, check session cleanup and whether the workload can reuse browsers with appropriate isolation; see [patterns.md](patterns.md). Retrieve current limits and pricing when sizing a workload rather than relying on fixed tier tables.

--- a/skills/cloudflare/references/browser-rendering/patterns.md
+++ b/skills/cloudflare/references/browser-rendering/patterns.md
@@ -1,91 +1,12 @@
-# Browser Rendering Patterns
+# Browser Run Patterns
 
-## Basic Worker
+Use the current examples for the selected integration instead of translating between Puppeteer, Playwright, and Quick Actions by changing method names.
 
-```typescript
-import puppeteer from "@cloudflare/puppeteer";
+| Task | Documentation |
+|------|---------------|
+| Implement screenshots, PDFs, or extraction | [Quick Actions](https://developers.cloudflare.com/browser-run/quick-actions/) — choose the action and follow its example |
+| Build custom interactions | [Puppeteer](https://developers.cloudflare.com/browser-run/puppeteer/) or [Playwright](https://developers.cloudflare.com/browser-run/playwright/) — browser automation examples |
+| Reconnect across requests | [Reuse sessions](https://developers.cloudflare.com/browser-run/features/reuse-sessions/) — disconnect/reconnect lifecycle and when to use Durable Objects for stateful ownership |
+| Share browser capacity while isolating users | [Concurrency and session isolation](https://developers.cloudflare.com/browser-run/limits/#how-can-i-manage-concurrency-and-session-isolation-with-browser-run) — tabs, browser contexts, and capacity tradeoffs |
 
-export default {
-  async fetch(request, env) {
-    const browser = await puppeteer.launch(env.MYBROWSER);
-    try {
-      const page = await browser.newPage();
-      await page.goto("https://example.com");
-      return new Response(await page.content());
-    } finally {
-      await browser.close(); // ALWAYS in finally
-    }
-  }
-};
-```
-
-## Session Reuse
-
-Keep sessions alive for performance:
-```typescript
-let sessionId = await env.SESSION_KV.get("browser-session");
-if (sessionId) {
-  browser = await puppeteer.connect(env.MYBROWSER, sessionId);
-} else {
-  browser = await puppeteer.launch(env.MYBROWSER, { keep_alive: 600000 });
-  await env.SESSION_KV.put("browser-session", browser.sessionId(), { expirationTtl: 600 });
-}
-// Don't close browser to keep session alive
-```
-
-## Common Operations
-
-| Task | Code |
-|------|------|
-| Screenshot | `await page.screenshot({ type: "png", fullPage: true })` |
-| PDF | `await page.pdf({ format: "A4", printBackground: true })` |
-| Extract data | `await page.evaluate(() => document.querySelector('h1').textContent)` |
-| Fill form | `await page.type('#input', 'value'); await page.click('button')` |
-| Wait nav | `await Promise.all([page.waitForNavigation(), page.click('a')])` |
-
-## Parallel Scraping
-
-```typescript
-const pages = await Promise.all(urls.map(() => browser.newPage()));
-await Promise.all(pages.map((p, i) => p.goto(urls[i])));
-const titles = await Promise.all(pages.map(p => p.title()));
-```
-
-## Playwright Selectors
-
-```typescript
-import { launch } from "@cloudflare/playwright";
-const browser = await launch(env.MYBROWSER);
-await page.getByRole("button", { name: "Sign in" }).click();
-await page.getByLabel("Email").fill("user@example.com");
-await page.getByTestId("submit-button").click();
-```
-
-## Incognito Contexts
-
-Isolated sessions without multiple browsers:
-```typescript
-const ctx1 = await browser.createIncognitoBrowserContext();
-const ctx2 = await browser.createIncognitoBrowserContext();
-// Each has isolated cookies/storage
-```
-
-## Quota Check
-
-```typescript
-const limits = await puppeteer.limits(env.MYBROWSER);
-if (limits.remaining < 60000) return new Response("Quota low", { status: 429 });
-```
-
-## Error Handling
-
-```typescript
-try {
-  await page.goto(url, { timeout: 30000, waitUntil: "networkidle0" });
-} catch (e) {
-  if (e.message.includes("timeout")) return new Response("Timeout", { status: 504 });
-  if (e.message.includes("Session limit")) return new Response("Too many sessions", { status: 429 });
-} finally {
-  if (browser) await browser.close();
-}
-```
+Quick Actions manage their own session lifecycle. For sessions managed by the application, close pages and browsers on completion or failure. If reuse is intentional, follow the client's disconnect/reconnect semantics and handle expired sessions; closing the browser ends it. Keep cookies and storage isolated between users, and coordinate ownership when several requests can reconnect to the same session.


### PR DESCRIPTION
The Browser Rendering references duplicate API examples, configuration, and tier limits that have drifted from the current Browser Run documentation. They also treat REST versus Workers as the automation boundary, although Quick Actions now support both interfaces and external clients can use persistent CDP sessions.

Replace the five references with task-specific links to the maintained docs, following #122. Retain guidance for choosing an integration, checking runtime and package compatibility, and managing session reuse, isolation, ownership, and cleanup. Keep existing filenames and incoming routes; reduce the reference material from 443 to 67 lines.

Validation: checked the linked documentation and coverage against the Browser Run documentation index, verified local links and the session-isolation anchor, ran `quick_validate.py skills/cloudflare`, and passed `git diff --check`. Documentation-only change; no runtime tests needed.
