### PR TITLE
docs: remove obsolete build skills from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 | sandbox-migrate-to-next | Port a stable Sandbox app to `@cloudflare/sandbox@next` |
 | wrangler | Deploying and managing Workers, KV, R2, D1, Vectorize, Queues, Workflows |
 | web-perf | Auditing Core Web Vitals (FCP, LCP, TBT, CLS), render-blocking resources, network chains |
-| building-mcp-server-on-cloudflare | Building remote MCP servers with tools, OAuth, and deployment |
-| building-ai-agent-on-cloudflare | Building AI agents with state, WebSockets, and tool integration |
 
 ## Cloudflare One
 


### PR DESCRIPTION
The README advertised two build skills that are no longer shipped. Remove those two inventory rows; the existing build-agent and build-mcp commands remain documented.

Validation: confirmed both skill directories are absent, both command files exist and remain listed in the README, and `git diff --check` passes.
