### PR TITLE
docs: list omitted shipped skills in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 | sandbox-stable | Sandbox on the current stable `@cloudflare/sandbox` package |
 | sandbox-migrate-to-next | Port a stable Sandbox app to `@cloudflare/sandbox@next` |
 | wrangler | Deploying and managing Workers, KV, R2, D1, Vectorize, Queues, Workflows |
+| workers-best-practices | Writing, reviewing, or configuring production Workers |
+| cloudflare-email-service | Implementing or troubleshooting Email Sending, Email Routing, and delivery configuration |
+| turnstile-spin | Setting up, repairing, or migrating Turnstile bot verification, including server-side Siteverify |
 | web-perf | Auditing Core Web Vitals (FCP, LCP, TBT, CLS), render-blocking resources, network chains |
 | building-mcp-server-on-cloudflare | Building remote MCP servers with tools, OAuth, and deployment |
 | building-ai-agent-on-cloudflare | Building AI agents with state, WebSockets, and tool integration |


### PR DESCRIPTION
The README omitted three shipped skills, making them harder to discover. Add concise inventory entries for `workers-best-practices`, `cloudflare-email-service`, and `turnstile-spin`, using their existing skill descriptions.

Validation: checked each entry against its shipped `SKILL.md`; `git diff --check` passes. This documentation-only change adds three table rows and no skill content.
