### PR TITLE
Fix skill reference paths in build commands

### DIFF
--- a/commands/build-agent.md
+++ b/commands/build-agent.md
@@ -12,10 +12,12 @@ The user invoked this command with: $ARGUMENTS
 
 ## Instructions
 
+Resolve the Markdown links below relative to this command file.
+
 When this command is invoked:
 
-1. Read the skill file at `agents-sdk/SKILL.md` for core SDK guidance, APIs, and wrangler config
-2. Based on what the user wants to build, read the relevant references from `agents-sdk/references/`:
+1. Read the [Agents SDK skill](../skills/agents-sdk/SKILL.md) for core SDK guidance, APIs, and wrangler config
+2. Based on what the user wants to build, read the relevant references from [Agents SDK references](../skills/agents-sdk/references/):
    - For chat/AI agents: `streaming-chat.md`, `client-sdk.md`
    - For scheduled or server-initiated chat turns: `server-driven-messages.md`
    - For state management: `state-scheduling.md`

--- a/commands/build-mcp.md
+++ b/commands/build-mcp.md
@@ -12,7 +12,9 @@ The user invoked this command with: $ARGUMENTS
 
 ## Instructions
 
-Read `agents-sdk/SKILL.md` for SDK guidance and `agents-sdk/references/mcp.md` for the relevant developer documentation. Follow the linked server and security guides for scaffolding, dependency versions, implementation, and authentication; use the migration guide when adapting an existing server. Validate the requested tools and endpoint locally before deployment.
+Resolve the Markdown links below relative to this command file.
+
+Read the [Agents SDK skill](../skills/agents-sdk/SKILL.md) for SDK guidance and the [MCP reference](../skills/agents-sdk/references/mcp.md) for the relevant developer documentation. Follow the linked server and security guides for scaffolding, dependency versions, implementation, and authentication; use the migration guide when adapting an existing server. Validate the requested tools and endpoint locally before deployment.
 
 ## Example Usage
 


### PR DESCRIPTION
The build commands referenced `agents-sdk/` as though it were in the caller’s working directory, but the bundled content lives under `skills/agents-sdk/`. Link to those existing files relative to each command and explicitly state how to resolve the links.

Validation: all four relative Markdown targets exist; `git diff --check` passes. Installed-host command execution was not tested.
