### PR TITLE
fix: reuse Wrangler guidance for agent deployment

### DIFF
--- a/commands/build-agent.md
+++ b/commands/build-agent.md
@@ -38,7 +38,7 @@ When this command is invoked:
 3. **Implement agent class**: extend `Agent` or `AIChatAgent` depending on use case
 4. **Wire routing**: `routeAgentRequest` in the default export
 5. **Build client**: `useAgent` + `useAgentChat` React hooks
-6. **Deploy**: `npx wrangler deploy`
+6. **Deploy**: Follow the [Wrangler skill](../skills/wrangler/SKILL.md) for the project's build workflow, deployment target, and validation; see [Agents deployment](https://developers.cloudflare.com/agents/getting-started/quick-start/#deploy-to-cloudflare).
 
 ## Key Decision: Agent vs AIChatAgent vs Think
 


### PR DESCRIPTION
The build-agent command invoked Wrangler directly, bypassing the existing deployment workflow. Route that step through the Wrangler skill for project builds, deployment targets, and validation, and link Cloudflare's Agents deployment documentation.

Validation: checked the local skill link, verified the linked developer documentation, and ran `git diff --check`. This changes one instruction and adds no reference content.
