### PR TITLE
docs(c3): replace stale Next.js Pages examples with docs links

### DIFF
--- a/skills/cloudflare/references/c3/README.md
+++ b/skills/cloudflare/references/c3/README.md
@@ -11,7 +11,7 @@ npm create cloudflare@latest my-app
 # Worker (API/WebSocket/Cron)
 npm create cloudflare@latest my-api -- --type=hello-world --ts
 
-# Pages (static/SSG/full-stack)
+# Pages (static/SSG)
 npm create cloudflare@latest my-site -- --type=web-app --framework=astro --platform=pages
 ```
 
@@ -29,16 +29,17 @@ What are you building?
 │       npm create cloudflare@latest my-site -- --type=web-app --framework=astro --platform=pages
 
 ├─ Full-stack app (Next.js/Remix/SvelteKit)
-│   ├─ Need Durable Objects, Queues, or Workers-only features?
-│   │   └─ Workers (default)
-│   └─ Otherwise use Pages for git integration and branch previews
-│       └─ Add --platform=pages
+│   └─ Follow the current framework guide below
 
 └─ Convert existing project
     └─ npm create cloudflare@latest . -- --type=pre-existing --existing-script=./src/worker.ts
 ```
 
 **Critical:** Pages projects require `--platform=pages` flag. Without it, C3 defaults to Workers.
+
+## Framework Setup
+
+Fetch the [Workers framework guide](https://developers.cloudflare.com/workers/framework-guides/) for the chosen framework before scaffolding or adapting an existing app. For Next.js, follow [Next.js on Workers](https://developers.cloudflare.com/workers/framework-guides/web-apps/nextjs/); use the [Pages static export guide](https://developers.cloudflare.com/pages/framework-guides/nextjs/deploy-a-static-nextjs-site/) only when targeting a Next.js static export on Pages.
 
 ## Interactive Flow
 

--- a/skills/cloudflare/references/c3/api.md
+++ b/skills/cloudflare/references/c3/api.md
@@ -50,18 +50,17 @@ CF_TELEMETRY_DISABLED=1     # Disable telemetry
 
 ## Examples
 
+For framework apps, follow [Framework Setup](README.md#framework-setup).
+
 ```bash
 # TypeScript Worker
 npm create cloudflare@latest my-api -- --type=hello-world --lang=ts --no-deploy
-
-# Next.js on Pages
-npm create cloudflare@latest my-app -- --type=web-app --framework=next --platform=pages --ts
 
 # Astro blog
 npm create cloudflare@latest my-blog -- --type=web-app --framework=astro --ts --deploy
 
 # CI: non-interactive
-npm create cloudflare@latest my-app -- --type=web-app --framework=next --ts --no-git --no-deploy
+npm create cloudflare@latest my-api -- --type=hello-world --lang=ts --no-git --no-deploy
 
 # GitHub template
 npm create cloudflare@latest -- --template=cloudflare/templates/worker-openapi

--- a/skills/cloudflare/references/c3/patterns.md
+++ b/skills/cloudflare/references/c3/patterns.md
@@ -2,12 +2,11 @@
 
 ## Quick Workflows
 
+For framework apps, follow [Framework Setup](README.md#framework-setup).
+
 ```bash
 # TypeScript API Worker
 npm create cloudflare@latest my-api -- --type=hello-world --lang=ts --deploy
-
-# Next.js on Pages
-npm create cloudflare@latest my-app -- --type=web-app --framework=next --platform=pages --ts --deploy
 
 # Astro static site  
 npm create cloudflare@latest my-blog -- --type=web-app --framework=astro --platform=pages --ts
@@ -67,10 +66,9 @@ npm create cloudflare@latest my-app -- --template=../my-template
 ```bash
 # Add Cloudflare to existing Worker
 npm create cloudflare@latest . -- --type=pre-existing --existing-script=./dist/index.js
-
-# Add to existing framework app
-npm create cloudflare@latest . -- --type=web-app --framework=next --platform=pages --ts
 ```
+
+For existing framework apps, follow [Framework Setup](README.md#framework-setup).
 
 ## Post-Creation Checklist
 


### PR DESCRIPTION
C3 references previously sent general Next.js apps to Pages. Remove those scaffold/migration examples and the full-stack Pages default, and route setup through current Cloudflare framework documentation. The Pages link is explicitly for Next.js static exports; adapter instructions remain upstream.

Verified sources: [framework guides](https://developers.cloudflare.com/workers/framework-guides/), [Next.js on Workers](https://developers.cloudflare.com/workers/framework-guides/web-apps/nextjs/), and [Next.js static export on Pages](https://developers.cloudflare.com/pages/framework-guides/nextjs/deploy-a-static-nextjs-site/).

Validation: read all three linked guides, checked the local Framework Setup anchors, and ran `git diff --check`. Documentation only; 3 files, 13 insertions and 15 deletions.
