### PR TITLE
docs(wrangler): route runtime verification to developer docs

### DIFF
--- a/skills/wrangler/SKILL.md
+++ b/skills/wrangler/SKILL.md
@@ -47,4 +47,6 @@ After changing config or bindings in a TypeScript project, regenerate types with
 
 For deployment changes, use the project's build workflow and `wrangler deploy --dry-run` where supported, with the intended config and environment. A successful dry run checks the build and packaging; it does not prove remote resources or runtime behavior work. Use task-specific local or remote checks as appropriate to the requested work.
 
+When runtime or binding behavior needs verification, follow the [integration test harness](https://developers.cloudflare.com/workers/testing/test-harness/) to exercise Worker builds and inspect relevant binding state; use its [Playwright integration](https://developers.cloudflare.com/workers/testing/test-harness/integrations/#playwright) for browser user flows. Reuse existing tests and keep coverage focused on the change. Distinguish [local simulation and remote bindings](https://developers.cloudflare.com/workers/local-development/) when reporting results. For deployed runtime failures, consult [Workers logs](https://developers.cloudflare.com/workers/observability/logs/).
+
 Report what changed, the target environment, checks performed, and any unresolved validation gaps. Link the documentation used when the result depends on current command or configuration behavior.


### PR DESCRIPTION
The Wrangler skill leaves runtime verification at an unspecified local or remote check after a deploy dry run. Add one short paragraph to its existing Validate section that routes relevant Worker/binding checks to the integration harness and browser user flows to its Playwright integration, while keeping test coverage scoped to the change and distinguishing local simulation from remote resources.

All added technical guidance links to existing developer documentation:

- [Integration test harness](https://developers.cloudflare.com/workers/testing/test-harness/)
- [Playwright integration](https://developers.cloudflare.com/workers/testing/test-harness/integrations/#playwright)
- [Local development and remote bindings](https://developers.cloudflare.com/workers/local-development/)
- [Workers logs](https://developers.cloudflare.com/workers/observability/logs/)

Validation: read the linked documentation, verified the Playwright section, reviewed the diff, and passed `git diff --check`. Documentation-only change; no runtime tests were needed.
