### PR TITLE
Align skill discovery and the README with packaged workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Clone this repo and copy the skill folders into the appropriate directory for yo
 
 ## Commands
 
-Commands are user-invocable slash commands that you explicitly call.
+These Claude Code plugin commands are explicitly invoked shortcuts. Other clients can ask for the same workflows through the `agents-sdk` skill; portable Agent Plugins only discover skills and MCP servers, not `commands/`.
 
 | Command | Description |
 |---------|-------------|
@@ -83,8 +83,9 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 | sandbox-migrate-to-next | Port a stable Sandbox app to `@cloudflare/sandbox@next` |
 | wrangler | Deploying and managing Workers, KV, R2, D1, Vectorize, Queues, Workflows |
 | web-perf | Auditing Core Web Vitals (FCP, LCP, TBT, CLS), render-blocking resources, network chains |
-| building-mcp-server-on-cloudflare | Building remote MCP servers with tools, OAuth, and deployment |
-| building-ai-agent-on-cloudflare | Building AI agents with state, WebSockets, and tool integration |
+| workers-best-practices | Writing, reviewing, and configuring production Workers |
+| cloudflare-email-service | Email Sending, Email Routing, and delivery configuration |
+| turnstile-spin | Adding, repairing, or migrating Turnstile verification in an existing frontend and backend |
 
 ## Cloudflare One
 

--- a/commands/build-agent.md
+++ b/commands/build-agent.md
@@ -12,10 +12,12 @@ The user invoked this command with: $ARGUMENTS
 
 ## Instructions
 
+Resolve bundled files from `${CLAUDE_PLUGIN_ROOT}`, the installed plugin directory, rather than the user project or current working directory.
+
 When this command is invoked:
 
-1. Read the skill file at `agents-sdk/SKILL.md` for core SDK guidance, APIs, and wrangler config
-2. Based on what the user wants to build, read the relevant references from `agents-sdk/references/`:
+1. Read the skill file at `${CLAUDE_PLUGIN_ROOT}/skills/agents-sdk/SKILL.md` for core SDK guidance, APIs, and wrangler config
+2. Based on what the user wants to build, read the relevant references from `${CLAUDE_PLUGIN_ROOT}/skills/agents-sdk/references/`:
    - For chat/AI agents: `streaming-chat.md`, `client-sdk.md`
    - For scheduled or server-initiated chat turns: `server-driven-messages.md`
    - For state management: `state-scheduling.md`

--- a/commands/build-mcp.md
+++ b/commands/build-mcp.md
@@ -12,7 +12,9 @@ The user invoked this command with: $ARGUMENTS
 
 ## Instructions
 
-Read `agents-sdk/SKILL.md` for SDK guidance and `agents-sdk/references/mcp.md` for the relevant developer documentation. Follow the linked server and security guides for scaffolding, dependency versions, implementation, and authentication; use the migration guide when adapting an existing server. Validate the requested tools and endpoint locally before deployment.
+Resolve bundled files from `${CLAUDE_PLUGIN_ROOT}`, the installed plugin directory, rather than the user project or current working directory.
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/agents-sdk/SKILL.md` for SDK guidance and `${CLAUDE_PLUGIN_ROOT}/skills/agents-sdk/references/mcp.md` for the relevant developer documentation. Follow the linked server and security guides for scaffolding, dependency versions, implementation, and authentication; use the migration guide when adapting an existing server. Validate the requested tools and endpoint locally before deployment.
 
 ## Example Usage
 

--- a/skills/agents-sdk/SKILL.md
+++ b/skills/agents-sdk/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: agents-sdk
-description: Build, debug, or review Cloudflare Agents SDK applications using the agents package.
+description: Build, debug, or review AI agents and remote MCP servers on Cloudflare using the Agents SDK, including tools, authentication, and deployment.
 ---
 
 # Cloudflare Agents SDK
 
 Your knowledge of the Agents SDK may be outdated. **Prefer retrieval over pre-training** for any Agents SDK task.
+
+## Build workflows
+
+For a new AI agent, read [configuration](references/configuration.md) and [routing](references/routing.md), then the references for the requested capabilities below. Inspect an existing project's dependencies and setup before adding to it.
+
+For a remote MCP server, start with [MCP](references/mcp.md). Follow its linked server and security guides for the handler API, tools, authentication, and migrations. Validate the requested tools and endpoint locally before deployment. These workflows are available directly through this skill, including clients without slash-command support.
 
 ## Retrieval Sources
 

--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -22,6 +22,23 @@ Fetch the **latest** information before citing specific numbers, API signatures,
 
 When a reference file and the docs disagree, **trust the docs**. This is especially important for: numeric limits, pricing tiers, type signatures, and configuration options.
 
+## Specialized workflows
+
+When a dedicated skill is available in the current installation, use it for the workflow below. For skills-only installations that omit it, use the product references in this skill and current documentation.
+
+| Request | Skill |
+|---|---|
+| Build an AI agent or remote MCP server on Cloudflare | agents-sdk |
+| Write or review production Workers | workers-best-practices |
+| Run Wrangler commands or configure deployment | wrangler |
+| Build stateful coordination with Durable Objects | durable-objects |
+| Send transactional email or route incoming email | cloudflare-email-service |
+| Add or repair Turnstile on an existing form/backend | turnstile-spin |
+| Plan or operate Zero Trust/SASE | cloudflare-one |
+| Migrate another VPN/SWG/SASE platform | cloudflare-one-migrations |
+| Use Sandbox stable, preview, or migrate between them | sandbox-stable, sandbox-next, sandbox-migrate-to-next |
+| Diagnose website loading or interaction performance | web-perf |
+
 ## Quick Decision Trees
 
 ### "I need feature flags"

--- a/skills/cloudflare/references/durable-objects/README.md
+++ b/skills/cloudflare/references/durable-objects/README.md
@@ -182,4 +182,4 @@ npx wrangler deploy           # Deploy + auto-apply migrations
 
 - **[DO Storage](../do-storage/README.md)** - SQLite, KV, transactions (detailed storage guide)
 - **[Workers](../workers/README.md)** - Core Workers runtime features
-- **[WebSockets](../websockets/README.md)** - WebSocket APIs and patterns
+- **[WebSockets](./api.md)** - WebSocket APIs and patterns

--- a/skills/cloudflare/references/tunnel/README.md
+++ b/skills/cloudflare/references/tunnel/README.md
@@ -125,5 +125,5 @@ ingress:
 ## See Also
 
 - [workers](../workers/) - Workers with Tunnel integration
-- [access](../access/) - Zero Trust access policies
-- [warp](../warp/) - WARP client for private networks
+- [Cloudflare One](../../../cloudflare-one/SKILL.md) - Zero Trust access policies
+- [Cloudflare One](../../../cloudflare-one/SKILL.md) - WARP client for private networks

--- a/tests/activation.md
+++ b/tests/activation.md
@@ -1,0 +1,15 @@
+# Skill discovery scenarios
+
+Run these in fresh sessions with the plugin installed, using disposable fixtures. Record client/version, loaded skills, and observed behavior. Do not configure accounts or deploy during discovery checks. These are behavioral scenarios, not automated assertions about model routing.
+
+| Prompt | Expected routing and behavior |
+|---|---|
+| Build a remote MCP server on Cloudflare with two read-only tools. | agents-sdk; retrieve MCP handler and security guidance; no dependency on slash commands. |
+| Build a Cloudflare AI agent with persistent chat. | agents-sdk; use configuration, routing, and chat references. |
+| Add Turnstile to this existing signup form and backend. | turnstile-spin; inspect the existing handler and preserve its behavior. |
+| Send transactional email from this Worker. | cloudflare-email-service; retrieve sending/binding guidance. |
+| Review this Worker for production readiness. | workers-best-practices; inspect installed versions and configuration. |
+| Which Cloudflare storage product fits this workload? | cloudflare; compare relevant product references. |
+| Build an MCP server for a local desktop app; do not use Cloudflare. | Do not select a Cloudflare implementation merely because MCP is mentioned. |
+
+Repeat the first three prompts with a skills-only installation and a client without `commands/` support. Confirm the workflow remains discoverable. If a skill is absent, report that capability rather than pretending it was loaded.


### PR DESCRIPTION
The README advertised two removed skills and omitted three shipped skills. Correct the inventory, identify the build commands as Claude Code shortcuts, and make AI-agent/MCP builds discoverable directly through agents-sdk. Add explicit umbrella routing to specialized workflows without duplicating their instructions.

Add fresh-session activation scenarios, including a non-Cloudflare negative case and skills-only installation. Validation: all 13 skills pass skills-ref and the README inventory matches the skill directories. Activation scenarios are documented but were not executed in separate model sessions. Addresses audit finding 2.

Stacked on https://github.com/cloudflare/skills/pull/143. Review this PR against its current base; merge the prerequisite first, then retarget to main.
