### PR TITLE
Repair bundled command paths and missing reference links

### DIFF
--- a/commands/build-agent.md
+++ b/commands/build-agent.md
@@ -12,10 +12,12 @@ The user invoked this command with: $ARGUMENTS
 
 ## Instructions
 
+Resolve bundled files from `${CLAUDE_PLUGIN_ROOT}`, the installed plugin directory, rather than the user project or current working directory.
+
 When this command is invoked:
 
-1. Read the skill file at `agents-sdk/SKILL.md` for core SDK guidance, APIs, and wrangler config
-2. Based on what the user wants to build, read the relevant references from `agents-sdk/references/`:
+1. Read the skill file at `${CLAUDE_PLUGIN_ROOT}/skills/agents-sdk/SKILL.md` for core SDK guidance, APIs, and wrangler config
+2. Based on what the user wants to build, read the relevant references from `${CLAUDE_PLUGIN_ROOT}/skills/agents-sdk/references/`:
    - For chat/AI agents: `streaming-chat.md`, `client-sdk.md`
    - For scheduled or server-initiated chat turns: `server-driven-messages.md`
    - For state management: `state-scheduling.md`

--- a/commands/build-mcp.md
+++ b/commands/build-mcp.md
@@ -12,7 +12,9 @@ The user invoked this command with: $ARGUMENTS
 
 ## Instructions
 
-Read `agents-sdk/SKILL.md` for SDK guidance and `agents-sdk/references/mcp.md` for the relevant developer documentation. Follow the linked server and security guides for scaffolding, dependency versions, implementation, and authentication; use the migration guide when adapting an existing server. Validate the requested tools and endpoint locally before deployment.
+Resolve bundled files from `${CLAUDE_PLUGIN_ROOT}`, the installed plugin directory, rather than the user project or current working directory.
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/agents-sdk/SKILL.md` for SDK guidance and `${CLAUDE_PLUGIN_ROOT}/skills/agents-sdk/references/mcp.md` for the relevant developer documentation. Follow the linked server and security guides for scaffolding, dependency versions, implementation, and authentication; use the migration guide when adapting an existing server. Validate the requested tools and endpoint locally before deployment.
 
 ## Example Usage
 

--- a/skills/cloudflare/references/durable-objects/README.md
+++ b/skills/cloudflare/references/durable-objects/README.md
@@ -182,4 +182,4 @@ npx wrangler deploy           # Deploy + auto-apply migrations
 
 - **[DO Storage](../do-storage/README.md)** - SQLite, KV, transactions (detailed storage guide)
 - **[Workers](../workers/README.md)** - Core Workers runtime features
-- **[WebSockets](../websockets/README.md)** - WebSocket APIs and patterns
+- **[WebSockets](./api.md)** - WebSocket APIs and patterns

--- a/skills/cloudflare/references/tunnel/README.md
+++ b/skills/cloudflare/references/tunnel/README.md
@@ -125,5 +125,5 @@ ingress:
 ## See Also
 
 - [workers](../workers/) - Workers with Tunnel integration
-- [access](../access/) - Zero Trust access policies
-- [warp](../warp/) - WARP client for private networks
+- [Cloudflare One](../../../cloudflare-one/SKILL.md) - Zero Trust access policies
+- [Cloudflare One](../../../cloudflare-one/SKILL.md) - WARP client for private networks


### PR DESCRIPTION
Build commands referred to `agents-sdk/` even though the installed files live under `skills/agents-sdk/`. Anchor reads to `${CLAUDE_PLUGIN_ROOT}` and repair the three missing reference targets using existing bundled guidance.

Validation: local Markdown targets resolve; command targets resolve from an unrelated temporary working directory. No live client invocation was needed for the filesystem checks. Addresses audit finding 3.

Stacked on https://github.com/cloudflare/skills/pull/144. Review this PR against its current base; merge the prerequisite first, then retarget to main.
