### PR TITLE
Validate skill and plugin packaging in CI

### DIFF
--- a/.github/workflows/validate-package.yml
+++ b/.github/workflows/validate-package.yml
@@ -1,0 +1,19 @@
+name: Validate skill package
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: python -m pip install -r scripts/requirements-validation.txt
+      - run: python scripts/validate-package.py
+      - run: python -m unittest discover -s tests -p 'test_*.py' -v
+      - run: python -m unittest discover -s skills/turnstile-spin/tests -p 'test_*.py' -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 pr.md
 TODO.md
+
+__pycache__/
+*.py[cod]
+.venv/

--- a/schemas/agent-plugins-1.0.0/README.md
+++ b/schemas/agent-plugins-1.0.0/README.md
@@ -1,0 +1,3 @@
+# Agent Plugins v1 schemas
+
+Vendored from [plugin.schema.json](https://agent-plugins.org/schemas/1.0.0/plugin.schema.json) and [mcp.schema.json](https://agent-plugins.org/schemas/1.0.0/mcp.schema.json) on 2026-09-05. The specification text remains authoritative. Review schema updates explicitly; validation never fetches a schema at runtime. These schemas validate the portable root files, not native client manifests.

--- a/schemas/agent-plugins-1.0.0/mcp.schema.json
+++ b/schemas/agent-plugins-1.0.0/mcp.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "title": "Agent Plugins MCP Configuration",
+  "description": "Machine-readable schema for mcp.json in Agent Plugins 1.0.0. The Agent Plugins specification defines additional semantic and operational requirements.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+      "description": "Canonical identifier of the MCP configuration schema for the Agent Plugins version targeted by this document."
+    },
+    "mcpServers": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/server"
+      }
+    }
+  },
+  "required": ["$schema", "mcpServers"],
+  "additionalProperties": false,
+  "$defs": {
+    "server": {
+      "title": "MCP server",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/stdioServer"
+        },
+        {
+          "$ref": "#/$defs/streamableHttpServer"
+        },
+        {
+          "$ref": "#/$defs/sseServer"
+        }
+      ]
+    },
+    "stdioServer": {
+      "title": "stdio MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "stdio"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Executable token. Resolution rules are defined by the Agent Plugins specification."
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "object",
+          "propertyNames": {
+            "not": {
+              "enum": ["PLUGIN_ROOT", "PLUGIN_DATA"]
+            }
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "cwd": {
+          "type": "string",
+          "pattern": "^(?:\\./|\\$\\{PLUGIN_ROOT\\}(?:/|$)|\\$\\{PLUGIN_DATA\\}(?:/|$))",
+          "description": "Plugin-relative, PLUGIN_ROOT-rooted, or PLUGIN_DATA-rooted working directory. Filesystem containment is validated separately."
+        }
+      },
+      "required": ["type", "command"],
+      "additionalProperties": false
+    },
+    "streamableHttpServer": {
+      "title": "Streamable HTTP MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "streamable-http"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "MCP endpoint URL. URL semantics are defined by the Agent Plugins specification."
+        },
+        "headers": {
+          "$ref": "#/$defs/headers"
+        }
+      },
+      "required": ["type", "url"],
+      "additionalProperties": false
+    },
+    "sseServer": {
+      "title": "Legacy HTTP+SSE MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "sse"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "MCP endpoint URL. URL semantics are defined by the Agent Plugins specification."
+        },
+        "headers": {
+          "$ref": "#/$defs/headers"
+        }
+      },
+      "required": ["type", "url"],
+      "additionalProperties": false
+    },
+    "headers": {
+      "title": "HTTP headers",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/agent-plugins-1.0.0/plugin.schema.json
+++ b/schemas/agent-plugins-1.0.0/plugin.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "title": "Agent Plugins Manifest",
+  "description": "Machine-readable schema for plugin.json in Agent Plugins 1.0.0. The Agent Plugins specification defines additional semantic and operational requirements.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+      "description": "Canonical identifier of the plugin manifest schema for the Agent Plugins version targeted by this document."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^(?!.*(?:--|\\.\\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$",
+      "description": "Human-readable plugin name."
+    },
+    "version": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "author": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "homepage": {
+      "type": "string"
+    },
+    "repository": {
+      "type": "string"
+    },
+    "license": {
+      "type": "string"
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Client-specific manifest data keyed by reverse-domain extension namespace. Agent Plugins assigns no semantics to namespace object contents.",
+      "additionalProperties": {
+        "type": "object"
+      }
+    }
+  },
+  "required": ["$schema", "name"],
+  "additionalProperties": false
+}

--- a/scripts/requirements-validation.txt
+++ b/scripts/requirements-validation.txt
@@ -1,0 +1,3 @@
+skills-ref @ git+https://github.com/agentskills/agentskills.git@69ef37e9424c0a7ea9dd2293b559e43ec8176379#subdirectory=skills-ref
+jsonschema==4.26.0
+markdown-it-py==4.0.0

--- a/scripts/validate-package.py
+++ b/scripts/validate-package.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate portable packaging and shared native adapter contracts, offline."""
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+from jsonschema import Draft202012Validator
+from markdown_it import MarkdownIt
+from skills_ref import validate
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def check(root):
+    errors = []
+
+    def error(path, message):
+        errors.append(f"{path.relative_to(root)}: {message}")
+
+    def target(owner, value, base, prefix=False):
+        if prefix and not value.startswith('./'):
+            error(owner, f"package path must start with './': {value}")
+        resolved = (base / value).resolve()
+        if not resolved.is_relative_to(root.resolve()) or not resolved.exists():
+            error(owner, f"missing or escaping package path: {value}")
+
+    portable = {}
+    for name in ('plugin', 'mcp'):
+        path = root / f'{name}.json'
+        data = json.loads(path.read_text())
+        schema = json.loads((root / 'schemas/agent-plugins-1.0.0' / f'{name}.schema.json').read_text())
+        for problem in Draft202012Validator(schema).iter_errors(data):
+            error(path, problem.message)
+        portable[name] = data
+
+    for filename in ('.codex-plugin/plugin.json', '.claude-plugin/plugin.json', '.cursor-plugin/plugin.json'):
+        path = root / filename
+        data = json.loads(path.read_text())
+        for key in ('name', 'version', 'description'):
+            if data.get(key) != portable['plugin'].get(key):
+                error(path, f'{key} differs from portable manifest')
+        for key in ('skills', 'mcpServers'):
+            if key in data:
+                target(path, data[key], root, prefix=True)
+        interface = data.get('interface', {})
+        for value in [interface.get('logo'), interface.get('composerIcon'), *interface.get('screenshots', [])]:
+            if value:
+                target(path, value, root, prefix=True)
+        if 'logo' in data:  # Cursor's native logo field does not require './'.
+            target(path, data['logo'], root)
+
+    native = json.loads((root / '.mcp.json').read_text())['mcpServers']
+    normalized = {name: {**server, 'type': 'streamable-http' if server['type'] == 'http' else server['type']}
+                  for name, server in native.items()}
+    if normalized != portable['mcp']['mcpServers']:
+        error(root / '.mcp.json', 'native and portable MCP definitions differ')
+
+    skills = {p.parent.name: p.parent for p in (root / 'skills').glob('*/SKILL.md')}
+    for path in skills.values():
+        for problem in validate(path):
+            error(path / 'SKILL.md', problem)
+    readme = (root / 'README.md').read_text().split('## Skills\n', 1)[1].split('## MCP Servers', 1)[0]
+    listed = set(re.findall(r'^\| ([a-z][a-z0-9-]+) \|', readme, re.M))
+    if listed != set(skills):
+        error(root / 'README.md', f'skill inventory: missing {sorted(set(skills)-listed)}, stale {sorted(listed-set(skills))}')
+
+    # Git's inventory excludes environments, installed packages, and local scratch files.
+    tracked = subprocess.check_output(['git', '-C', str(root), 'ls-files', '-z'], text=True).split('\0')
+    parser = MarkdownIt()
+    for filename in filter(None, tracked):
+        path = root / filename
+        if path.is_symlink():
+            target(path, path.name, path.parent)
+        if path.suffix == '.md':
+            for token in parser.parse(path.read_text()):
+                for child in token.children or []:
+                    attr = 'href' if child.type == 'link_open' else 'src' if child.type == 'image' else None
+                    value = child.attrGet(attr) if attr else None
+                    if value:
+                        parsed = urlsplit(value)
+                        if not parsed.scheme and not parsed.netloc and parsed.path:
+                            target(path, unquote(parsed.path), path.parent)
+            if filename.startswith('commands/'):
+                for value in re.findall(r'`\$\{CLAUDE_PLUGIN_ROOT\}/([^`]+)`', path.read_text()):
+                    target(path, value, root)
+        if filename.startswith('skills/') and '/scripts/' in filename and path.suffix == '.sh':
+            if not path.stat().st_mode & 0o111:
+                error(path, 'packaged shell helper is not executable')
+            result = subprocess.run(['bash', '-n', str(path)], capture_output=True, text=True)
+            if result.returncode:
+                error(path, result.stderr.strip())
+    return errors
+
+
+if __name__ == '__main__':
+    problems = check(ROOT)
+    print('\n'.join(problems) if problems else 'Package validation passed')
+    sys.exit(bool(problems))

--- a/skills/turnstile-spin/tests/test_helpers.py
+++ b/skills/turnstile-spin/tests/test_helpers.py
@@ -1,0 +1,87 @@
+"""Offline helper contracts. No real account, credentials, or network access."""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / 'scripts'
+
+
+class HelperTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.bin = self.root / 'bin'; self.bin.mkdir()
+        for name, source in [('python3', sys.executable), ('jq', shutil.which('jq')), ('basename', shutil.which('basename'))]:
+            if source:
+                (self.bin / name).symlink_to(source)
+        curl = self.bin / 'curl'
+        curl.write_text('#!' + sys.executable + '''
+import os,sys
+sys.stdin.read()
+assert 'CLOUDFLARE_API_TOKEN' not in os.environ
+assert 'fake-token' not in ' '.join(sys.argv)
+if os.environ.get('FAIL_CURL') == '1': sys.exit(7)
+print(os.environ['FAKE_RESPONSE'])
+if '--write-out' in sys.argv: print('403')
+''')
+        curl.chmod(0o755)
+        self.env = {'PATH': str(self.bin), 'CLOUDFLARE_API_TOKEN': 'fake-token',
+                    'CLOUDFLARE_ACCOUNT_ID': 'fake-account', 'FAKE_RESPONSE': '{}'}
+
+    def run_helper(self, name, args=(), data=''):
+        return subprocess.run(['/bin/bash', str(SCRIPTS / name), *args], cwd=self.root,
+                              env=self.env, input=data, text=True, capture_output=True)
+
+    def test_missing_auth(self):
+        del self.env['CLOUDFLARE_API_TOKEN']
+        r = self.run_helper('auth-probe.sh')
+        self.assertEqual(json.loads(r.stdout)['status'], 'missing_token')
+
+    def test_missing_argument(self):
+        r = self.run_helper('widget-create.sh', ['--name'])
+        self.assertEqual(r.returncode, 2)
+
+    def test_missing_dependency(self):
+        (self.bin / 'python3').unlink()
+        r = self.run_helper('widget-create.sh', ['--account-id','x','--name','test','--domains','example.com'])
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn('python3 is required', r.stderr)
+
+    def test_api_errors_do_not_echo_remote_message(self):
+        for response in ['not json', json.dumps({'success':False,'errors':[{'code':10000,'message':'UNTRUSTED_REMOTE_TEXT'}]})]:
+            with self.subTest(response=response):
+                self.env['FAKE_RESPONSE'] = response
+                r = self.run_helper('widget-create.sh', ['--account-id','x','--name','test','--domains','example.com'])
+                self.assertNotEqual(r.returncode, 0)
+                self.assertEqual(json.loads(r.stdout)['status'], 'error')
+                self.assertNotIn('UNTRUSTED_REMOTE_TEXT', r.stdout+r.stderr)
+                self.assertNotIn('fake-token', r.stdout+r.stderr)
+
+    def test_network_failure(self):
+        self.env['FAIL_CURL'] = '1'
+        r = self.run_helper('widget-create.sh', ['--account-id','x','--name','test','--domains','example.com'])
+        self.assertNotEqual(r.returncode, 0)
+        self.assertEqual(json.loads(r.stdout)['code'], 0)
+
+    @unittest.skipUnless(shutil.which('jq'), 'jq required for validator tests')
+    def test_wrong_widget_secret_rejected(self):
+        self.env['FAKE_RESPONSE'] = json.dumps({'success':True,'result':{'sitekey':'key','secret':'different-secret','domains':['example.com'],'clearance_level':'no_clearance'}})
+        r = self.run_helper('validate.sh', ['--sitekey','key','--account-id','x','--expected-domains','["example.com"]'], 'fake-secret')
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn('does not belong', r.stderr)
+        self.assertNotIn('different-secret', r.stdout+r.stderr)
+
+    def test_persistence_rejects_file_target(self):
+        r = self.run_helper('persist-skill.sh', ['--path', 'rules.md'])
+        self.assertNotEqual(r.returncode, 0)
+        self.assertEqual(json.loads(r.stdout)['reason'], 'file_target_not_supported')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/skills/turnstile-spin/tests/validation.md
+++ b/skills/turnstile-spin/tests/validation.md
@@ -60,3 +60,5 @@ Expected exit code: 0. File-oriented rules targets install the hosted `prompt.md
 The consuming test harness must pass the widget secret through standard input. It must not export it or place it in a command argument.
 
 (`run-all.sh` is not bundled with this skill; the cases above are intended to be wired into the consuming agent's own test harness, or run by hand after a deploy.)
+
+Offline helper checks are available in `test_helpers.py`: run `python -m unittest discover -s skills/turnstile-spin/tests -v` from the repository root. They use synthetic responses and never contact Cloudflare. The live cases above remain separate.

--- a/tests/client-smoke.md
+++ b/tests/client-smoke.md
@@ -1,0 +1,19 @@
+# Package and client checks
+
+Run `python -m pip install -r scripts/requirements-validation.txt`, then `python scripts/validate-package.py`, `python -m unittest discover -s tests -v`, and `python -m unittest discover -s skills/turnstile-spin/tests -v` from a checkout. Python 3.12, Git, Bash, and jq are needed for all offline checks. Missing jq skips the relevant helper test; release checks should not skip it. The reference validator is pinned; its upstream describes it as a demonstration library, so it supplements rather than replaces the other checks.
+
+For releases, record client/version, installed revision, observed components, and pass/fail evidence in the release PR. Use disposable projects; do not connect an account or deploy merely to test discovery.
+
+| Client/install | Check |
+|---|---|
+| Portable Agent Plugins v1 loader | Discover `skills/*/SKILL.md` and `mcp.json`; retain the portable `streamable-http` transport. Do not assume native command/rule support. |
+| Codex plugin | Discover skills, icon, starter prompts, and the Cloudflare MCP configuration from the native manifest. Confirm whether the native `mcpServers` wrapper is accepted. |
+| Claude Code plugin | Discover skills and both commands. Invoke a build command from a project outside the plugin root; confirm its reference reads resolve inside the installed plugin. |
+| Cursor plugin | Confirm skill and native rule discovery using the client installation path; record which command capabilities the tested client actually supports. |
+| Skills-only installation | Run the [activation scenarios](activation.md) with no plugin MCP configuration. Use available documentation retrieval and report unavailable live account tools. |
+| Browser tooling absent | Ask for a performance audit; continue useful analysis and report unmeasured trace metrics without inventing values. |
+| Cloudflare MCP disconnected | Confirm skills remain usable for local work; report unavailable account operations and connect only within the requested task scope. |
+
+Native adapter directories and `commands/`/`rules/` support client formats. They are not implementations of Agent Plugins' reverse-domain extension mechanism. Preserve them until client support for another layout is verified.
+
+Live Turnstile checks remain in [validation.md](../skills/turnstile-spin/tests/validation.md). Run them separately against an explicitly selected test account and backend. Offline tests mock curl and use synthetic values; they do not validate cloud access or end-to-end Turnstile behavior.

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,49 @@
+"""Check observable validator failures using disposable, tracked packages."""
+import importlib.util
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location('validator', ROOT / 'scripts/validate-package.py')
+validator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(validator)
+
+
+class PackageTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name) / 'package'
+        shutil.copytree(ROOT, self.root, ignore=shutil.ignore_patterns('.git', '__pycache__', '.venv'))
+        subprocess.run(['git', 'init', '-q', str(self.root)], check=True)
+        subprocess.run(['git', '-C', str(self.root), 'add', '.'], check=True)
+
+    def test_valid_package(self):
+        self.assertEqual(validator.check(self.root), [])
+
+    def test_version_drift(self):
+        p = self.root / '.codex-plugin/plugin.json'
+        data = json.loads(p.read_text()); data['version'] = '99.0.0'
+        p.write_text(json.dumps(data))
+        self.assertTrue(any('version differs' in e for e in validator.check(self.root)))
+
+    def test_missing_reference_and_stale_inventory(self):
+        p = self.root / 'README.md'
+        p.write_text(p.read_text().replace('| agents-sdk |', '| nonexistent-skill |') + '\n[missing](missing.md)\n')
+        errors = validator.check(self.root)
+        self.assertTrue(any('skill inventory' in e for e in errors))
+        self.assertTrue(any('missing.md' in e for e in errors))
+
+    def test_escaping_asset(self):
+        p = self.root / '.codex-plugin/plugin.json'
+        data = json.loads(p.read_text()); data['interface']['logo'] = '../outside.svg'
+        p.write_text(json.dumps(data))
+        self.assertTrue(any('escaping package path' in e for e in validator.check(self.root)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add CI checks for skill frontmatter, vendored portable JSON schemas, native adapter metadata/MCP consistency, component and asset paths, README inventory, local links, command paths, and packaged shell helpers. Ignore Python test caches and virtual environments.

Add four validator regression tests and seven offline Turnstile helper tests covering invalid arguments, missing dependencies, network/API failures, secret mismatch, and invalid persistence targets. Add a client smoke-test matrix that distinguishes local validation from live account checks.

Validation: package validation and all 11 included tests pass. On a temporary integration branch containing all eight audit fixes, package validation and all 29 tests pass. Tests use synthetic responses and do not contact Cloudflare. Addresses audit finding 4.

Stacked on https://github.com/cloudflare/skills/pull/145. Review this PR against its current base; merge the prerequisite first, then retarget to main.
