### PR TITLE
Declare skill requirements and preflight Turnstile dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ Short, retrieval-first skills for [Cloudflare One](https://developers.cloudflare
 | cloudflare-one | Designing, configuring, troubleshooting, or reviewing Cloudflare One deployments across Access, Gateway, WARP, Tunnel, Magic WAN, DLP, CASB, posture, and identity |
 | cloudflare-one-migrations | Migration assessments, policy mapping, rollout plans, and gap analysis for Zscaler, Palo Alto, legacy VPN/SWG, and SASE migrations to Cloudflare One |
 
+## Requirements
+
+| Capability | Bundled tools | Additional requirements |
+|---|---|---|
+| Platform guidance | Skill references; Cloudflare MCP configuration with plugin installs | Documentation retrieval/network access for current API facts. Skills-only installs do not configure MCP. |
+| Live Cloudflare operations | Main Cloudflare remote MCP configuration | Connect the intended account; access depends on the operation and account permissions. |
+| Web performance measurements | Performance workflow | Browser trace/network tools such as Chrome DevTools MCP, installed separately. Without them, source analysis remains available and trace metrics are unmeasured. |
+| Turnstile setup and validation | Bash helper scripts | Bash, curl, Python 3, jq, Cloudflare API/Siteverify network access, and appropriate account access. Run the bundled dependency preflight first. |
+| Turnstile local env-file destination | Ignore-check procedure | Git and an existing ignored destination. |
+| Turnstile existing-widget recovery | Guarded recovery workflow | Approved canonical Wrangler 4.109+ executable and target account authentication. |
+
 ## MCP Servers
 
 This plugin includes Cloudflare's main [remote MCP server](https://developers.cloudflare.com/agents/model-context-protocol/cloudflare/servers-for-cloudflare/) for enhanced functionality:

--- a/skills/turnstile-spin/SKILL.md
+++ b/skills/turnstile-spin/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: turnstile-spin
 description: Set up, repair, or migrate to Cloudflare Turnstile bot verification in an existing frontend and backend, including server-side Siteverify.
+compatibility: Requires Bash, curl, Python 3, jq, and network access to Cloudflare. Local env-file writes also require Git. Existing-widget recovery requires an approved Wrangler 4.109+ executable; widget management requires account access.
 ---
 
 # Turnstile Spin skill
@@ -34,6 +35,10 @@ Load when the user's prompt mentions any of:
 - A specific signup, login, contact form, download, comment, API endpoint, or other user-triggered request combined with "Cloudflare" or "bot"
 
 Do not load for unrelated Cloudflare tasks (Workers, Pages, R2, etc.) unless Turnstile is also mentioned.
+
+## Dependency preflight
+
+Before the wizard or existing-widget flow, resolve `scripts/preflight.sh` from this loaded skill's directory and run it while keeping the user's project as the working directory. It checks dependencies without using credentials, installing software, or contacting Cloudflare. If `missing_dependencies` is returned, report the named requirements and use an available supported environment or ask for the missing setup; do not start auth/widget operations. Re-run with `--env-file` before choosing a local env-file destination to check Git as well. Resolve and verify the approved Wrangler executable separately when the selected flow requires it.
 
 ## Choose the flow before responding
 

--- a/skills/turnstile-spin/scripts/preflight.sh
+++ b/skills/turnstile-spin/scripts/preflight.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Check local dependencies without credentials, installs, or network requests.
+set -eu
+commands=(bash curl python3 jq)
+for arg in "$@"; do
+  case "$arg" in
+    --env-file) commands+=(git) ;;
+    *) printf 'preflight: unknown argument: %s\n' "$arg" >&2; exit 2 ;;
+  esac
+done
+missing=()
+for name in "${commands[@]}"; do
+  command -v "$name" >/dev/null 2>&1 || missing+=("$name")
+done
+if (( ${#missing[@]} )); then
+  printf '{"status":"missing_dependencies","missing":['
+  sep=''
+  for name in "${missing[@]}"; do
+    printf '%s"%s"' "$sep" "$name"
+    sep=','
+  done
+  printf ']}\n'
+  exit 1
+fi
+printf '{"status":"ok"}\n'

--- a/skills/turnstile-spin/tests/test_preflight.py
+++ b/skills/turnstile-spin/tests/test_preflight.py
@@ -1,0 +1,32 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'scripts/preflight.sh'
+
+
+class PreflightTests(unittest.TestCase):
+    def test_reports_missing_tools_without_python(self):
+        with tempfile.TemporaryDirectory() as d:
+            r = subprocess.run(['/bin/bash',str(SCRIPT)],env={'PATH':d},capture_output=True,text=True)
+        self.assertEqual(r.returncode,1)
+        self.assertEqual(json.loads(r.stdout)['missing'],['bash','curl','python3','jq'])
+
+    def test_checks_only_selected_requirements_without_running_them(self):
+        with tempfile.TemporaryDirectory() as d:
+            for name in ['bash','curl','python3','jq']:
+                p=Path(d)/name; p.write_text('#!/bin/sh\nexit 99\n'); p.chmod(0o755)
+            r=subprocess.run(['/bin/bash',str(SCRIPT)],env={'PATH':d},capture_output=True,text=True)
+            self.assertEqual(json.loads(r.stdout),{'status':'ok'})
+            r=subprocess.run(['/bin/bash',str(SCRIPT),'--env-file'],env={'PATH':d},capture_output=True,text=True)
+            self.assertEqual(json.loads(r.stdout)['missing'],['git'])
+
+    def test_unknown_option(self):
+        r=subprocess.run(['/bin/bash',str(SCRIPT),'--install'],capture_output=True,text=True)
+        self.assertEqual(r.returncode,2)
+
+
+if __name__ == '__main__': unittest.main()

--- a/skills/web-perf/SKILL.md
+++ b/skills/web-perf/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: web-perf
 description: Audit, diagnose, or optimize website loading and interaction performance, Core Web Vitals, and Lighthouse performance scores.
+compatibility: Performance measurements require browser trace/network tools such as Chrome DevTools MCP, which this plugin does not bundle. Source analysis can proceed without them. Internet access is needed for current documentation.
 ---
 
 # Web Performance Audit


### PR DESCRIPTION
Expose the browser and shell requirements for web-perf and turnstile-spin in compatibility metadata and a README matrix. Add a credential-free Turnstile preflight before auth/widget operations, with an additional Git check when selecting a local env-file destination. Preserve the browser workflow's fallback when trace tools are unavailable.

Validation: three preflight tests pass, including an empty PATH and fake tools that must never execute. Local preflight passes. All skills pass the pinned upstream skills-ref validator when combined with the frontmatter repair. The bundled local skill-creator quick validator rejects `compatibility` because its allowlist is older; the current Agent Skills specification explicitly supports that field (https://agentskills.io/specification). Addresses audit finding 5.

Stacked on https://github.com/cloudflare/skills/pull/143. Review this PR against its current base; merge the prerequisite first, then retarget to main.
