### PR TITLE
Make build-agent guidance portable across hosts

### DIFF
--- a/commands/build-agent.md
+++ b/commands/build-agent.md
@@ -1,58 +1,9 @@
 ---
 description: Build an AI agent on Cloudflare using the Agents SDK
-argument-hint: [agent-description]
-allowed-tools: [Read, Glob, Grep, Bash, Write, Edit, WebFetch]
 ---
 
 # Build AI Agent on Cloudflare
 
-## Arguments
+Use the user's agent description and conversation context as the requirements.
 
-The user invoked this command with: $ARGUMENTS
-
-## Instructions
-
-When this command is invoked:
-
-1. Read the skill file at `agents-sdk/SKILL.md` for core SDK guidance, APIs, and wrangler config
-2. Based on what the user wants to build, read the relevant references from `agents-sdk/references/`:
-   - For chat/AI agents: `streaming-chat.md`, `client-sdk.md`
-   - For scheduled or server-initiated chat turns: `server-driven-messages.md`
-   - For state management: `state-scheduling.md`
-   - For RPC methods: `callable.md`
-   - For background work: `workflows.md`, `durable-execution.md`, `queue-retries.md`
-   - For MCP integration: `mcp.md`
-   - For email handling: `email.md`
-   - For webhooks/push: `webhooks-push.md`
-   - For approval flows: `human-in-the-loop.md`
-   - For voice: `voice.md`
-   - For browser tools: `browse-the-web.md`
-   - For higher-level chat: `think.md`
-3. Fetch the relevant pages from https://developers.cloudflare.com/agents/ for the latest API details
-4. Always start with `configuration.md` and `routing.md` for project setup
-
-## Scaffold Steps
-
-1. **Create project**: `npx create-cloudflare@latest --template cloudflare/agents-starter`
-2. **Configure wrangler.jsonc**: DO bindings, migrations, AI binding, assets
-3. **Implement agent class**: extend `Agent` or `AIChatAgent` depending on use case
-4. **Wire routing**: `routeAgentRequest` in the default export
-5. **Build client**: `useAgent` + `useAgentChat` React hooks
-6. **Deploy**: `npx wrangler deploy`
-
-## Key Decision: Agent vs AIChatAgent vs Think
-
-| Need | Use | Package |
-|------|-----|---------|
-| Custom stateful logic, RPC, scheduling | `Agent` | `agents` |
-| AI chat with streaming, tools, persistence | `AIChatAgent` | `@cloudflare/ai-chat` |
-| AI chat with automatic tool loop, built-in workspace | `Think` | `@cloudflare/think` (experimental) |
-
-## Example Usage
-
-```
-/build-agent a customer support chatbot with tool calling
-/build-agent a real-time collaborative editor with state sync
-/build-agent a background processing agent with scheduled tasks
-/build-agent a voice assistant that can browse the web
-```
+Read and follow [the Agents SDK skill](../skills/agents-sdk/SKILL.md), starting with its **Build an Agent** workflow. Resolve this path relative to this command file; in an installed environment, use the bundled `agents-sdk` skill.

--- a/skills/agents-sdk/SKILL.md
+++ b/skills/agents-sdk/SKILL.md
@@ -70,7 +70,30 @@ The Agents SDK provides:
 - **Browser tools** (experimental) — CDP-powered browsing via `agents/browser`
 - **Think** (experimental) — Higher-level chat agent via `@cloudflare/think`
 
-## FIRST: Verify Installation
+## Build an Agent
+
+Use the user's description to determine the required state, chat, scheduling, and integrations. Start with [configuration](references/configuration.md) and [routing](references/routing.md), then read the references below that match those requirements. Fetch the linked Cloudflare documentation for current API details using the host's available documentation or web tools.
+
+| Need | Use | Package |
+|------|-----|---------|
+| Custom stateful logic, RPC, scheduling | `Agent` | `agents` |
+| AI chat with streaming, tools, persistence | `AIChatAgent` | `@cloudflare/ai-chat` |
+| AI chat with automatic tool loop, built-in workspace | `Think` | `@cloudflare/think` (experimental) |
+
+1. For a new project, scaffold with `npx create-cloudflare@latest --template cloudflare/agents-starter`. For an existing project, follow the **Add to existing project** guide above.
+2. Configure `wrangler.jsonc` with Durable Object bindings and migrations, plus AI bindings and assets as needed.
+3. Implement the selected agent class and wire `routeAgentRequest` into the Worker entrypoint.
+4. If a client is needed, follow [client-sdk.md](references/client-sdk.md); for a React chat UI, use `useAgent` and `useAgentChat` as described in [streaming-chat.md](references/streaming-chat.md).
+5. Validate the requested behavior locally. When deployment is part of the user's request, deploy with `npx wrangler deploy`.
+
+Example requests:
+
+- Build a customer support chatbot with tool calling.
+- Build a real-time collaborative editor with state sync.
+- Build a background processing agent with scheduled tasks.
+- Build a voice assistant that can browse the web.
+
+## Verify Installation
 
 ```bash
 npm ls agents  # Should show agents package


### PR DESCRIPTION
The build-agent command embedded Claude-specific tool names, argument substitution, and slash-command examples alongside reusable Cloudflare guidance. Move the build workflow into the existing `agents-sdk` skill and reduce the command to a thin adapter that uses the user's request and links to the skill with a correct relative path.

The shared workflow covers new and existing projects, makes client setup conditional, and ties deployment to the user's request.

Validation: skill validator passed, local Markdown links resolve, and `git diff --check` passed.
