### PR TITLE
docs: replace AI Search reference copies with documentation routes

### DIFF
--- a/skills/cloudflare/references/ai-search/README.md
+++ b/skills/cloudflare/references/ai-search/README.md
@@ -1,138 +1,25 @@
-# Cloudflare AI Search Reference
+# Cloudflare AI Search
 
-Expert guidance for implementing Cloudflare AI Search (formerly AutoRAG), Cloudflare's managed semantic search and RAG service.
+Use AI Search for managed content indexing and retrieval, with optional answer generation. Start with [How AI Search works](https://developers.cloudflare.com/ai-search/concepts/how-ai-search-works/).
 
-## Overview
+## Choose the right product
 
-**AI Search** is a managed RAG (Retrieval-Augmented Generation) pipeline that combines:
-- Automatic semantic indexing of your content
-- Vector similarity search
-- Built-in LLM generation
+- **Managed search or RAG over your content:** AI Search.
+- **Custom embeddings and vector-index management:** [Vectorize](../vectorize/README.md).
+- **Model inference without a managed retrieval pipeline:** [Workers AI](../workers-ai/README.md).
 
-**Key value propositions:**
-- **Zero vector management** - No manual embedding, indexing, or storage
-- **Auto-indexing** - Content automatically re-indexed every 6 hours
-- **Built-in generation** - Optional AI response generation from retrieved context
-- **Multi-source** - Index from R2 buckets or website crawls
+For freshness requirements, read [Syncing](https://developers.cloudflare.com/ai-search/configuration/indexing/syncing/) for your data source before choosing an architecture. Use the current [limits and pricing](https://developers.cloudflare.com/ai-search/platform/limits-pricing/) instead of assuming a fixed indexing interval or account limit.
 
-**Data source options:**
-- **R2 bucket** - Index files from Cloudflare R2 (supports MD, TXT, HTML, PDF, DOC, CSV, JSON)
-- **Website** - Crawl and index website content (requires Cloudflare-hosted domain)
+## Find the right documentation
 
-**Indexing lifecycle:**
-- Automatic 6-hour refresh cycle
-- Manual "Force Sync" available (30s rate limit)
-- Not designed for real-time updates
+Read the linked page before implementing; these references route to the maintained documentation instead of copying API examples or configuration.
 
-## Quick Start
+| Task | Start here |
+|------|------------|
+| Build a new Worker integration | [Workers binding quick start](https://developers.cloudflare.com/ai-search/get-started/workers/) |
+| Choose an API or maintain an existing integration | [API routes](api.md) |
+| Connect data, configure indexing, or manage environments | [Configuration routes](configuration.md) |
+| Choose retrieval, generation, or tenant isolation patterns | [Pattern routes](patterns.md) |
+| Diagnose indexing, authentication, filters, or limits | [Troubleshooting routes](gotchas.md) |
 
-**1. Create AI Search instance in dashboard:**
-- Go to Cloudflare Dashboard → AI Search → Create
-- Choose data source (R2 or website)
-- Configure instance name and settings
-
-**2. Configure Worker:**
-
-```jsonc
-// wrangler.jsonc
-{
-  "ai": {
-    "binding": "AI"
-  }
-}
-```
-
-**3. Use in Worker:**
-
-```typescript
-export default {
-  async fetch(request, env) {
-    const answer = await env.AI.autorag("my-search-instance").aiSearch({
-      query: "How do I configure caching?",
-      model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
-    });
-    
-    return Response.json({ answer: answer.response });
-  }
-};
-```
-
-## When to Use AI Search
-
-### AI Search vs Vectorize
-
-| Factor | AI Search | Vectorize |
-|--------|-----------|-----------|
-| **Management** | Fully managed | Manual embedding + indexing |
-| **Use when** | Want zero-ops RAG pipeline | Need custom embeddings/control |
-| **Indexing** | Automatic (6hr cycle) | Manual via API |
-| **Generation** | Built-in optional | Bring your own LLM |
-| **Data sources** | R2 or website | Manual insert |
-| **Best for** | Docs, support, enterprise search | Custom ML pipelines, real-time |
-
-### AI Search vs Direct Workers AI
-
-| Factor | AI Search | Workers AI (direct) |
-|--------|-----------|---------------------|
-| **Context** | Automatic retrieval | Manual context building |
-| **Use when** | Need RAG (search + generate) | Simple generation tasks |
-| **Indexing** | Built-in | Not applicable |
-| **Best for** | Knowledge bases, docs | Simple chat, transformations |
-
-### search() vs aiSearch()
-
-| Method | Returns | Use When |
-|--------|---------|----------|
-| `search()` | Search results only | Building custom UI, need raw chunks |
-| `aiSearch()` | AI response + results | Need ready-to-use answer (chatbot, Q&A) |
-
-### Real-time Updates Consideration
-
-**AI Search is NOT ideal if:**
-- Need real-time content updates (<6 hours)
-- Content changes multiple times per hour
-- Strict freshness requirements
-
-**AI Search IS ideal if:**
-- Content relatively stable (docs, policies, knowledge bases)
-- 6-hour refresh acceptable
-- Prefer zero-ops over real-time
-
-## Platform Limits
-
-| Limit | Value |
-|-------|-------|
-| Max instances per account | 10 |
-| Max files per instance | 100,000 |
-| Max file size | 4 MB |
-| Index frequency | Every 6 hours |
-| Force Sync rate limit | Once per 30 seconds |
-| Filter nesting depth | 2 levels |
-| Filters per compound | 10 |
-| Score threshold range | 0.0 - 1.0 |
-
-## Reading Order
-
-Navigate these references based on your task:
-
-| Task | Read | Est. Time |
-|------|------|-----------|
-| **Understand AI Search** | README only | 5 min |
-| **Implement basic search** | README → api.md | 10 min |
-| **Configure data source** | README → configuration.md | 10 min |
-| **Production patterns** | patterns.md | 15 min |
-| **Debug issues** | gotchas.md | 10 min |
-| **Full implementation** | README → api.md → patterns.md | 30 min |
-
-## In This Reference
-
-- **[api.md](api.md)** - API endpoints, methods, TypeScript interfaces
-- **[configuration.md](configuration.md)** - Setup, data sources, wrangler config
-- **[patterns.md](patterns.md)** - Common patterns, decision guidance, code examples
-- **[gotchas.md](gotchas.md)** - Troubleshooting, code-level gotchas, limits
-
-## See Also
-
-- [Cloudflare AI Search Docs](https://developers.cloudflare.com/ai-search/)
-- [Workers AI Docs](https://developers.cloudflare.com/workers-ai/)
-- [Vectorize Docs](https://developers.cloudflare.com/vectorize/)
+Existing `env.AI.autorag()` integrations can continue to work. Use the [migration guide](https://developers.cloudflare.com/ai-search/api/migration/workers-binding/) when upgrading; migration is not required just to maintain an existing integration.

--- a/skills/cloudflare/references/ai-search/api.md
+++ b/skills/cloudflare/references/ai-search/api.md
@@ -1,87 +1,13 @@
-# AI Search API Reference
+# AI Search API Routes
 
-## Workers Binding
+Choose documentation that matches the integration you are working on. Fetch the reference before writing binding configuration, request types, response parsing, or streaming code.
 
-```typescript
-const answer = await env.AI.autorag("instance-name").aiSearch(options);
-const results = await env.AI.autorag("instance-name").search(options);
-const instances = await env.AI.autorag("_").listInstances();
-```
+| Task | Documentation |
+|------|---------------|
+| New Worker integration: bindings, search, chat completions, and streaming | [Search Workers binding](https://developers.cloudflare.com/ai-search/api/search/workers-binding/) |
+| Create, list, configure, and inspect instances | [Instances Workers binding](https://developers.cloudflare.com/ai-search/api/instances/workers-binding/) |
+| Query over HTTP and configure request authentication | [Search REST API](https://developers.cloudflare.com/ai-search/api/search/rest-api/) |
+| Maintain an existing `env.AI.autorag()` integration | [Legacy Workers binding](https://developers.cloudflare.com/ai-search/api/migration/workers-binding-legacy/) |
+| Upgrade a legacy binding, including responses, streaming, and filters | [Workers binding migration](https://developers.cloudflare.com/ai-search/api/migration/workers-binding/) |
 
-## aiSearch() Options
-
-```typescript
-interface AiSearchOptions {
-  query: string;                          // User query
-  model: string;                          // Workers AI model ID
-  system_prompt?: string;                 // LLM instructions
-  rewrite_query?: boolean;                // Fix typos (default: false)
-  max_num_results?: number;               // Max chunks (default: 10)
-  ranking_options?: { score_threshold?: number }; // 0.0-1.0 (default: 0.3)
-  reranking?: { enabled: boolean; model: string };
-  stream?: boolean;                       // Stream response (default: false)
-  filters?: Filter;                       // Metadata filters
-  page?: string;                          // Pagination token
-}
-```
-
-## Response
-
-```typescript
-interface AiSearchResponse {
-  search_query: string;      // Query used (rewritten if enabled)
-  response: string;          // AI-generated answer
-  data: SearchResult[];      // Retrieved chunks
-  has_more: boolean;
-  next_page?: string;
-}
-
-interface SearchResult {
-  id: string;
-  score: number;
-  content: string;
-  metadata: { filename: string; folder: string; timestamp: number };
-}
-```
-
-## Filters
-
-```typescript
-// Comparison
-{ column: "folder", operator: "gte", value: "docs/" }
-
-// Compound
-{ operator: "and", filters: [
-  { column: "folder", operator: "gte", value: "docs/" },
-  { column: "timestamp", operator: "gte", value: 1704067200 }
-]}
-```
-
-**Operators:** `eq`, `ne`, `gt`, `gte`, `lt`, `lte`
-
-**Built-in metadata:** `filename`, `folder`, `timestamp` (Unix seconds)
-
-## Streaming
-
-```typescript
-const stream = await env.AI.autorag("docs").aiSearch({ query, model, stream: true });
-return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
-```
-
-## Error Types
-
-| Error | Cause |
-|-------|-------|
-| `AutoRAGNotFoundError` | Instance doesn't exist |
-| `AutoRAGUnauthorizedError` | Invalid/missing token |
-| `AutoRAGValidationError` | Invalid parameters |
-
-## REST API
-
-```bash
-curl https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/autorag/rags/{NAME}/ai-search \
-  -H "Authorization: Bearer {TOKEN}" \
-  -d '{"query": "...", "model": "@cf/meta/llama-3.3-70b-instruct-fp8-fast"}'
-```
-
-Requires Service API token with "AI Search - Read" permission.
+The legacy binding remains supported; use current bindings for new integrations. Keep legacy request and response handling together until deliberately migrating them.

--- a/skills/cloudflare/references/ai-search/configuration.md
+++ b/skills/cloudflare/references/ai-search/configuration.md
@@ -1,88 +1,16 @@
-# AI Search Configuration
+# AI Search Configuration Routes
 
-## Worker Setup
+| Task | Documentation |
+|------|---------------|
+| Set up a Worker and local development | [Workers binding quick start](https://developers.cloudflare.com/ai-search/get-started/workers/) |
+| Select built-in uploads, R2, or a website; check supported formats | [Data sources](https://developers.cloudflare.com/ai-search/configuration/data-source/) |
+| Connect existing R2 content | [R2 data source](https://developers.cloudflare.com/ai-search/configuration/data-source/r2/) |
+| Configure crawling and diagnose bot-protection requirements | [Website data source](https://developers.cloudflare.com/ai-search/configuration/data-source/website/) |
+| Include or exclude files and URL paths | [Path filtering](https://developers.cloudflare.com/ai-search/configuration/indexing/path-filtering/) |
+| Configure source syncs, trigger indexing, or pause and resume | [Syncing](https://developers.cloudflare.com/ai-search/configuration/indexing/syncing/) |
+| Grant AI Search access to R2 for indexing | [Service API token](https://developers.cloudflare.com/ai-search/configuration/indexing/service-api-token/) |
+| Organize instances by application, tenant, or environment | [Namespaces](https://developers.cloudflare.com/ai-search/concepts/namespaces/) |
+| Configure models | [Models](https://developers.cloudflare.com/ai-search/configuration/models/) |
+| Inspect instance configuration and indexing progress | [Instances Workers binding](https://developers.cloudflare.com/ai-search/api/instances/workers-binding/) |
 
-```jsonc
-// wrangler.jsonc
-{
-  "ai": { "binding": "AI" }
-}
-```
-
-```typescript
-interface Env {
-  AI: Ai;
-}
-
-const answer = await env.AI.autorag("my-instance").aiSearch({
-  query: "How do I configure caching?",
-  model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
-});
-```
-
-## Data Sources
-
-### R2 Bucket
-
-Dashboard: AI Search → Create Instance → Select R2 bucket
-
-**Supported formats:** `.md`, `.txt`, `.html`, `.pdf`, `.doc`, `.docx`, `.csv`, `.json`
-
-**Auto-indexed metadata:** `filename`, `folder`, `timestamp`
-
-### Website Crawler
-
-Requirements:
-- Domain on Cloudflare
-- `sitemap.xml` at root
-- Bot protection must allow `CloudflareAISearch` user agent
-
-## Path Filtering (R2)
-
-```
-docs/**/*.md          # All .md in docs/ recursively
-**/*.draft.md         # Exclude (use in exclude patterns)
-```
-
-## Indexing
-
-- **Automatic:** Every 6 hours
-- **Force Sync:** Dashboard button (30s rate limit between syncs)
-- **Pause:** Settings → Pause Indexing (existing index remains searchable)
-
-## Service API Token
-
-Dashboard: AI Search → Instance → Use AI Search → API → Create Token
-
-Permissions:
-- **Read** - search operations
-- **Edit** - instance management
-
-Store securely:
-```bash
-wrangler secret put AI_SEARCH_TOKEN
-```
-
-## Multi-Environment
-
-```toml
-# wrangler.toml
-[env.production.vars]
-AI_SEARCH_INSTANCE = "prod-docs"
-
-[env.staging.vars]
-AI_SEARCH_INSTANCE = "staging-docs"
-```
-
-```typescript
-const answer = await env.AI.autorag(env.AI_SEARCH_INSTANCE).aiSearch({ query });
-```
-
-## Monitoring
-
-```typescript
-const instances = await env.AI.autorag("_").listInstances();
-console.log(instances.find(i => i.name === "docs"));
-```
-
-Dashboard shows: files indexed, status, last index time, storage usage.
+Indexing credentials and request authentication serve different purposes. For authenticating search requests over HTTP, use the [Search REST API](https://developers.cloudflare.com/ai-search/api/search/rest-api/) documentation.

--- a/skills/cloudflare/references/ai-search/gotchas.md
+++ b/skills/cloudflare/references/ai-search/gotchas.md
@@ -1,81 +1,13 @@
-# AI Search Gotchas
+# AI Search Troubleshooting Routes
 
-## Type Safety
+| Symptom or question | Documentation |
+|---------------------|---------------|
+| API request fails, including authentication or missing instances | [API error codes](https://developers.cloudflare.com/ai-search/troubleshooting/api-error-codes/) |
+| Upload or sync succeeds but content fails during processing | [Indexing error codes](https://developers.cloudflare.com/ai-search/troubleshooting/indexing-error-codes/) |
+| Content is missing or stale | [Syncing](https://developers.cloudflare.com/ai-search/configuration/indexing/syncing/) and [supported data sources and formats](https://developers.cloudflare.com/ai-search/configuration/data-source/) |
+| Filters return unexpected documents or no matches | [Filtering](https://developers.cloudflare.com/ai-search/configuration/retrieval/filtering/) and [metadata attributes](https://developers.cloudflare.com/ai-search/configuration/indexing/metadata/) |
+| Thresholds exclude results or responses need tuning | [Result controls](https://developers.cloudflare.com/ai-search/configuration/retrieval/result-controls/) |
+| Binding types, response parsing, or streaming fail after an upgrade | [Workers binding migration](https://developers.cloudflare.com/ai-search/api/migration/workers-binding/) |
+| Capacity, file-size, or billing questions | [Limits and pricing](https://developers.cloudflare.com/ai-search/platform/limits-pricing/) |
 
-**Timestamp precision:** Use seconds (10-digit), not milliseconds.
-```typescript
-const nowInSeconds = Math.floor(Date.now() / 1000); // Correct
-```
-
-**Folder prefix matching:** Use `gte` for "starts with" on paths.
-```typescript
-filters: { column: "folder", operator: "gte", value: "docs/api/" } // Matches nested
-```
-
-## Filter Limitations
-
-| Limit | Value |
-|-------|-------|
-| Max nesting depth | 2 levels |
-| Filters per compound | 10 |
-| `or` operator | Same column, `eq` only |
-
-**OR restriction example:**
-```typescript
-// ✅ Valid: same column, eq only
-{ operator: "or", filters: [
-  { column: "folder", operator: "eq", value: "docs/" },
-  { column: "folder", operator: "eq", value: "guides/" }
-]}
-```
-
-## Indexing Issues
-
-| Problem | Cause | Solution |
-|---------|-------|----------|
-| File not indexed | Unsupported format or >4MB | Check format (.md/.txt/.html/.pdf/.doc/.csv/.json) |
-| Index out of sync | 6-hour index cycle | Wait or use "Force Sync" (30s rate limit) |
-| Empty results | Index incomplete | Check dashboard for indexing status |
-
-## Auth Errors
-
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `AutoRAGUnauthorizedError` | Invalid/missing token | Create Service API token with AI Search permissions |
-| `AutoRAGNotFoundError` | Wrong instance name | Verify exact name from dashboard |
-
-## Performance
-
-**Slow responses (>3s):**
-```typescript
-// Add score threshold + limit results
-ranking_options: { score_threshold: 0.5 },
-max_num_results: 10
-```
-
-**Empty results debug:**
-1. Remove filters, test basic query
-2. Lower `score_threshold` to 0.1
-3. Check index is populated
-
-## Limits
-
-| Resource | Limit |
-|----------|-------|
-| Instances per account | 10 |
-| Files per instance | 100,000 |
-| Max file size | 4 MB |
-| Index frequency | 6 hours |
-
-## Anti-Patterns
-
-**Use env vars for instance names:**
-```typescript
-const answer = await env.AI.autorag(env.AI_SEARCH_INSTANCE).aiSearch({...});
-```
-
-**Handle specific error types:**
-```typescript
-if (error instanceof AutoRAGNotFoundError) { /* 404 */ }
-if (error instanceof AutoRAGUnauthorizedError) { /* 401 */ }
-```
+For legacy binding behavior, start with [API routes](api.md). Do not apply current filter syntax or response shapes to legacy calls without following the migration guide.

--- a/skills/cloudflare/references/ai-search/patterns.md
+++ b/skills/cloudflare/references/ai-search/patterns.md
@@ -1,85 +1,15 @@
-# AI Search Patterns
+# AI Search Pattern Routes
 
-## search() vs aiSearch()
+Choose retrieval-only search when your application displays chunks or handles generation itself; choose chat completions when AI Search should also generate the answer. Read [Search Workers binding](https://developers.cloudflare.com/ai-search/api/search/workers-binding/) for both paths and streaming behavior.
 
-| Use | Method | Returns |
-|-----|--------|---------|
-| Custom UI, analytics | `search()` | Raw chunks only (~100-300ms) |
-| Chatbots, Q&A | `aiSearch()` | AI response + chunks (~500-2000ms) |
+| Task | Documentation |
+|------|---------------|
+| Isolate tenants using separate instances or a shared filtered instance | [Multitenancy](https://developers.cloudflare.com/ai-search/how-to/per-tenant-search/) |
+| Define built-in or custom metadata | [Metadata attributes](https://developers.cloudflare.com/ai-search/configuration/indexing/metadata/) |
+| Filter by metadata, combine conditions, or match a folder and subfolders | [Filtering](https://developers.cloudflare.com/ai-search/configuration/retrieval/filtering/) |
+| Tune result count and relevance thresholds | [Result controls](https://developers.cloudflare.com/ai-search/configuration/retrieval/result-controls/) |
+| Resolve follow-up queries using conversation context | [Query rewriting](https://developers.cloudflare.com/ai-search/configuration/retrieval/query-rewriting/) |
+| Improve result ordering with a second model | [Reranking](https://developers.cloudflare.com/ai-search/configuration/retrieval/reranking/) |
+| Customize generation and query-rewriting instructions | [System prompt](https://developers.cloudflare.com/ai-search/configuration/retrieval/system-prompt/) |
 
-## rewrite_query
-
-| Setting | Use When |
-|---------|----------|
-| `true` | User input (typos, vague queries) |
-| `false` | LLM-generated queries (already optimized) |
-
-## Multitenancy (Folder-Based)
-
-```typescript
-const answer = await env.AI.autorag("saas-docs").aiSearch({
-  query: "refund policy",
-  model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-  filters: {
-    column: "folder",
-    operator: "gte",  // "starts with" pattern
-    value: `tenants/${tenantId}/`
-  }
-});
-```
-
-## Streaming
-
-```typescript
-const stream = await env.AI.autorag("docs").aiSearch({
-  query, model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast", stream: true
-});
-return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
-```
-
-## Score Threshold
-
-| Threshold | Use |
-|-----------|-----|
-| 0.3 (default) | Broad recall, exploratory |
-| 0.5 | Balanced, production default |
-| 0.7 | High precision, critical accuracy |
-
-## System Prompt Template
-
-```typescript
-const systemPrompt = `You are a documentation assistant.
-- Answer ONLY based on provided context
-- If context doesn't contain answer, say "I don't have information"
-- Include code examples from context`;
-```
-
-## Compound Filters
-
-```typescript
-// OR: Multiple folders
-filters: {
-  operator: "or",
-  filters: [
-    { column: "folder", operator: "gte", value: "docs/api/" },
-    { column: "folder", operator: "gte", value: "docs/auth/" }
-  ]
-}
-
-// AND: Folder + date
-filters: {
-  operator: "and",
-  filters: [
-    { column: "folder", operator: "gte", value: "docs/" },
-    { column: "timestamp", operator: "gte", value: oneWeekAgoSeconds }
-  ]
-}
-```
-
-## Reranking
-
-Enable for high-stakes use cases (adds ~300ms latency):
-
-```typescript
-reranking: { enabled: true, model: "@cf/baai/bge-reranker-base" }
-```
+For tenant isolation, read the full multitenancy guide before choosing an approach. A lower-bound folder comparison alone does not establish a tenant boundary; use the documented filtering semantics.


### PR DESCRIPTION
The AI Search references direct new integrations to legacy AutoRAG examples and duplicate API shapes, filter recipes, indexing schedules, and capacity tables that have drifted from the product documentation. Replace that copied content with concise task-specific documentation routes, reducing the bundle from 479 to 82 lines while preserving all five entry files and the product-selection guidance.

New integrations route to current Workers bindings; existing `env.AI.autorag()` integrations retain a legacy reference and an optional migration path. Separate indexing credentials from search-request authentication, and route tenant isolation, folder filtering, source syncing, retrieval tuning, and troubleshooting to their maintained pages.

Validation:
- Read the current Cloudflare documentation behind all 25 external routes and checked removed-topic coverage, including the migration, multitenancy, filtering, syncing, and limits pages.
- Verified local Markdown links and repository inbound references; all five entry paths remain available.
- `git diff --check` passes. Documentation-only change; no runtime tests needed.

No documentation gap blocks this change. No API examples, signatures, numerical limits, or pricing tables are maintained locally.
