### PR TITLE
Route Agents Workflow integration to current documentation

### DIFF
--- a/skills/agents-sdk/references/workflows.md
+++ b/skills/agents-sdk/references/workflows.md
@@ -1,132 +1,21 @@
 # Workflows Integration
 
-Fetch https://developers.cloudflare.com/agents/api-reference/run-workflows/ for complete documentation.
+Use Agents for interactive communication and state management. Add a Workflow when a task needs durable multi-step execution, independent retries, or waits for external approval. Choose based on recovery needs; consult [Run Workflows](https://developers.cloudflare.com/agents/runtime/execution/run-workflows/) before implementing the integration.
 
-## Overview
+## Read for the task
 
-Agents handle real-time communication; Workflows handle durable execution. Together they enable:
+| Task | Documentation |
+| --- | --- |
+| Define a typed `AgentWorkflow`, start it from an Agent, and configure bindings | [Quick start](https://developers.cloudflare.com/agents/runtime/execution/run-workflows/#quick-start) |
+| Call back into the originating Agent and understand durable versus non-durable helpers | [AgentWorkflow class](https://developers.cloudflare.com/agents/runtime/execution/run-workflows/#agentworkflow-class) |
+| Send events, query instances, pause, resume, terminate, or delete tracked workflows | [Agent workflow methods](https://developers.cloudflare.com/agents/runtime/execution/run-workflows/#agent-workflow-methods) |
+| Receive progress, completion, errors, and custom events | [Lifecycle callbacks](https://developers.cloudflare.com/agents/runtime/execution/run-workflows/#lifecycle-callbacks) |
+| Approve or reject a waiting task | [Human-in-the-loop approval](https://developers.cloudflare.com/agents/runtime/execution/run-workflows/#human-in-the-loop-approval) |
+| Persist Workflow results into Agent state | [State synchronization](https://developers.cloudflare.com/agents/runtime/execution/run-workflows/#state-synchronization) |
+| Define steps, parameters, retries, and returned values | [Workers API](https://developers.cloudflare.com/workflows/build/workers-api/) |
 
-- Long-running background tasks with automatic retries
-- Human-in-the-loop approval flows
-- Multi-step pipelines that survive failures
+## Design checks
 
-| Use Case | Recommendation |
-|----------|----------------|
-| Chat/messaging | Agent only |
-| Quick API calls (<30s) | Agent only |
-| Background processing (<30s) | Agent `queue()` |
-| Long-running tasks (>30s) | Agent + Workflow |
-| Human approval flows | Agent + Workflow |
+Keep external side effects within durable steps, make retried operations idempotent, and persist the values needed after recovery through step results. Use the [Rules of Workflows](https://developers.cloudflare.com/workflows/build/rules-of-workflows/) to choose step boundaries.
 
-## AgentWorkflow Base Class
-
-```typescript
-import { AgentWorkflow } from "agents/workflows";
-import type { AgentWorkflowEvent, AgentWorkflowStep } from "agents/workflows";
-
-type TaskParams = { taskId: string; data: string };
-
-export class ProcessingWorkflow extends AgentWorkflow<MyAgent, TaskParams> {
-  async run(event: AgentWorkflowEvent<TaskParams>, step: AgentWorkflowStep) {
-    const params = event.payload;
-
-    // Durable step - retries on failure
-    const result = await step.do("process", async () => {
-      return processData(params.data);
-    });
-
-    // Non-durable: progress reporting
-    await this.reportProgress({ step: "process", percent: 0.5 });
-
-    // Non-durable: broadcast to connected clients
-    this.broadcastToClients({ type: "update", taskId: params.taskId });
-
-    // Durable: merge state via step
-    await step.mergeAgentState({ lastProcessed: params.taskId });
-
-    // Durable: report completion
-    await step.reportComplete(result);
-
-    return result;
-  }
-}
-```
-
-## Wrangler Configuration
-
-```jsonc
-{
-  "workflows": [
-    { "name": "processing-workflow", "binding": "PROCESSING_WORKFLOW", "class_name": "ProcessingWorkflow" }
-  ],
-  "durable_objects": {
-    "bindings": [{ "name": "MyAgent", "class_name": "MyAgent" }]
-  },
-  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["MyAgent"] }]
-}
-```
-
-## Agent Methods for Workflows
-
-```typescript
-// Start a workflow
-const instance = await this.runWorkflow("ProcessingWorkflow", { taskId: "123", data: "..." });
-
-// Send event to waiting workflow
-await this.sendWorkflowEvent("ProcessingWorkflow", workflowId, { type: "approve" });
-
-// Query workflows
-const workflow = await this.getWorkflow(workflowId);
-const workflows = await this.getWorkflows({ status: "running" });
-
-// Control workflows
-await this.approveWorkflow(workflowId);
-await this.rejectWorkflow(workflowId);
-await this.terminateWorkflow(workflowId);
-await this.pauseWorkflow(workflowId);
-await this.resumeWorkflow(workflowId);
-
-// Delete workflows
-await this.deleteWorkflow(workflowId);
-await this.deleteWorkflows({ status: "complete", before: new Date(...) });
-```
-
-## Lifecycle Callbacks
-
-```typescript
-export class MyAgent extends Agent<Env, State> {
-  async onWorkflowProgress(workflowName: string, workflowId: string, progress: unknown) {
-    // Workflow reported progress via this.reportProgress()
-    this.broadcast({ type: "progress", workflowId, progress });
-  }
-
-  async onWorkflowComplete(workflowName: string, workflowId: string, result?: unknown) {
-    // Workflow finished successfully
-  }
-
-  async onWorkflowError(workflowName: string, workflowId: string, error: Error) {
-    // Workflow failed
-  }
-
-  async onWorkflowEvent(workflowName: string, workflowId: string, event: unknown) {
-    // Workflow received an event via sendWorkflowEvent()
-  }
-}
-```
-
-## Human-in-the-Loop
-
-```typescript
-// In workflow: wait for approval
-const approved = await step.waitForEvent<{ approved: boolean }>("approval", {
-  timeout: "7d"
-});
-
-if (!approved.approved) {
-  throw new Error("Rejected");
-}
-
-// From agent: approve or reject
-await this.approveWorkflow(workflowId);  // Sends { approved: true }
-await this.rejectWorkflow(workflowId);   // Sends { approved: false }
-```
+Progress reports and client broadcasts may repeat on retry. Use the documented durable step helpers for persistent Agent state changes and completion reporting; see [bidirectional communication](https://developers.cloudflare.com/agents/runtime/execution/run-workflows/#bidirectional-communication).


### PR DESCRIPTION
The Agents SDK Workflow reference duplicates integration recipes that have drifted from the current API: its `runWorkflow` example supplies a class name instead of the configured binding name, and its approval example no longer follows the documented approval helper.

Replace the 132-line reference with 21 lines of task-specific links to the current integration guide, including setup, instance management, callbacks, approvals, and state synchronization. Retain the Agent-versus-Workflow decision and the recovery, idempotency, and durable-versus-non-durable communication guidance. Preserve the existing filename and inbound skill link.

This is the dedicated Agents integration follow-up to #122. The umbrella Workflows references were handled separately in #160; this PR changes only `skills/agents-sdk/references/workflows.md`.

Validation: read the linked Run Workflows, Workers API, and Rules of Workflows documentation for topic coverage; verified all ten URLs and the seven section fragments; checked the existing inbound reference; ran the skill-creator validator for `skills/agents-sdk` and `git diff --check`. Rebased onto current main after #160 merged. No documentation gaps found for the removed integration topics.
