### PR TITLE
docs(observability): replace copied recipes with documentation routes

### DIFF
--- a/skills/cloudflare/references/observability/README.md
+++ b/skills/cloudflare/references/observability/README.md
@@ -1,88 +1,27 @@
-# Cloudflare Observability Skill Reference
+# Cloudflare Observability
 
-**Purpose**: Comprehensive guidance for implementing observability in Cloudflare Workers, covering traces, logs, metrics, and analytics.
+Use this reference to choose a telemetry signal and find the maintained implementation guide. Fetch the linked documentation before writing configuration, queries, or export code; it is the source of truth for APIs, availability, retention, limits, and pricing.
 
-**Scope**: Cloudflare Observability features ONLY - Workers Logs, Traces, Analytics Engine, Logpush, Metrics & Analytics, and OpenTelemetry exports.
+## Choose a signal
 
----
+| Need | Start here |
+| --- | --- |
+| Store, search, and investigate historical Worker logs | [Workers Logs](https://developers.cloudflare.com/workers/observability/logs/workers-logs/) |
+| Watch a deployment or reproduce an issue live | [Real-time logs and Wrangler tail](https://developers.cloudflare.com/workers/observability/logs/real-time-logs/) |
+| Understand request flows and dependency latency | [Workers Traces](https://developers.cloudflare.com/workers/observability/traces/) |
+| Monitor built-in request, error, and CPU metrics | [Metrics and analytics](https://developers.cloudflare.com/workers/observability/metrics-and-analytics/) |
+| Record custom events and tenant-level usage for SQL analysis | [Analytics Engine](https://developers.cloudflare.com/analytics/analytics-engine/get-started/) |
+| Export logs and traces to an observability provider | [OpenTelemetry export](https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/) |
+| Apply custom filtering, transformation, or delivery logic | [Tail Workers](https://developers.cloudflare.com/workers/observability/logs/tail-workers/) |
+| Deliver Workers Trace Events to a supported log storage destination | [Workers Logpush](https://developers.cloudflare.com/workers/observability/logs/logpush/) |
 
-## Decision Tree: Which File to Load?
+Workers Logs supports retained historical data; live tailing is a separate debugging workflow. Choose persistence, sampling, and export destinations deliberately rather than assuming that every signal is stored or included without usage charges.
 
-Use this to route to the correct file without loading all content:
+## Load only what the task needs
 
-```
-├─ "How do I enable/configure X?"           → configuration.md
-├─ "What's the API/method/binding for X?"   → api.md
-├─ "How do I implement X pattern?"          → patterns.md
-│   ├─ Usage tracking/billing               → patterns.md
-│   ├─ Error tracking                       → patterns.md
-│   ├─ Performance monitoring               → patterns.md
-│   ├─ Multi-tenant tracking                → patterns.md
-│   ├─ Tail Worker filtering                → patterns.md
-│   └─ OpenTelemetry export                 → patterns.md
-└─ "Why isn't X working?" / "Limits?"       → gotchas.md
-```
+- [configuration.md](configuration.md): enable collection, bindings, environments, and exports.
+- [api.md](api.md): logging, telemetry types, SQL, GraphQL, and Logpush APIs.
+- [patterns.md](patterns.md): billing, performance, errors, tenant tracking, and export decisions.
+- [gotchas.md](gotchas.md): missing data, sampling, timing, privacy, and cost checks.
 
-## Reading Order
-
-Load files in this order based on task:
-
-| Task Type | Load Order | Reason |
-|-----------|------------|--------|
-| **Initial setup** | configuration.md → gotchas.md | Setup first, avoid pitfalls |
-| **Implement feature** | patterns.md → api.md → gotchas.md | Pattern → API details → edge cases |
-| **Debug issue** | gotchas.md → configuration.md | Common issues first |
-| **Query data** | api.md → patterns.md | API syntax → query examples |
-
-## Product Overview
-
-### Workers Logs
-- **What:** Console output from Workers (console.log/warn/error)
-- **Access:** Dashboard (Real-time Logs), Logpush, Tail Workers
-- **Cost:** Free (included with all Workers)
-- **Retention:** Real-time only (no historical storage in dashboard)
-
-### Workers Traces
-- **What:** Execution traces with timing, CPU usage, outcome
-- **Access:** Dashboard (Workers Analytics → Traces), Logpush
-- **Cost:** $0.10/1M spans (GA pricing starts March 1, 2026), 10M free/month
-- **Retention:** 14 days included
-
-### Analytics Engine
-- **What:** High-cardinality event storage and SQL queries
-- **Access:** SQL API, Dashboard (Analytics → Analytics Engine)
-- **Cost:** $0.25/1M writes beyond 10M free/month
-- **Retention:** 90 days (configurable up to 1 year)
-
-### Tail Workers
-- **What:** Workers that receive logs/traces from other Workers
-- **Use Cases:** Log filtering, transformation, external export
-- **Cost:** Standard Workers pricing
-
-### Logpush
-- **What:** Stream logs to external storage (S3, R2, Datadog, etc.)
-- **Access:** Dashboard, API
-- **Cost:** Requires Business/Enterprise plan
-
-## Pricing Summary (2026)
-
-| Feature | Free Tier | Cost Beyond Free Tier | Plan Requirement |
-|---------|-----------|----------------------|------------------|
-| Workers Logs | Unlimited | Free | Any |
-| Workers Traces | 10M spans/month | $0.10/1M spans | Paid Workers (GA: March 1, 2026) |
-| Analytics Engine | 10M writes/month | $0.25/1M writes | Paid Workers |
-| Logpush | N/A | Included in plan | Business/Enterprise |
-
-## In This Reference
-
-- **[configuration.md](configuration.md)** - Setup, deployment, configuration (Logs, Traces, Analytics Engine, Tail Workers, Logpush)
-- **[api.md](api.md)** - API endpoints, methods, interfaces (GraphQL, SQL, bindings, types)
-- **[patterns.md](patterns.md)** - Common patterns, use cases, examples (billing, monitoring, error tracking, exports)
-- **[gotchas.md](gotchas.md)** - Troubleshooting, best practices, limitations (common errors, performance gotchas, pricing)
-
-## See Also
-
-- [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
-- [Analytics Engine Docs](https://developers.cloudflare.com/analytics/analytics-engine/)
-- [Workers Traces Docs](https://developers.cloudflare.com/workers/observability/traces/)
-- [GraphQL Analytics API Reference](../graphql-api/) - Query Workers metrics, HTTP analytics, and 70+ other datasets via GraphQL
+For broader product tasks, see [Analytics Engine](../analytics-engine/README.md), [GraphQL API](../graphql-api/README.md), and [Tail Workers](../tail-workers/README.md).

--- a/skills/cloudflare/references/observability/api.md
+++ b/skills/cloudflare/references/observability/api.md
@@ -1,164 +1,20 @@
-## API Reference
+# Observability APIs
 
-### GraphQL Analytics API
+Fetch the applicable reference for current signatures, field locations, units, authentication, and query syntax. Do not infer the Tail event schema from an OpenTelemetry span or a Logpush record.
 
-**Endpoint**: `https://api.cloudflare.com/client/v4/graphql`
+| Task | Maintained documentation |
+| --- | --- |
+| Emit console messages and check supported methods | [Console API](https://developers.cloudflare.com/workers/runtime-apis/console/) |
+| Filter, group, and aggregate stored Workers Logs | [Query Builder](https://developers.cloudflare.com/workers/observability/query-builder/) |
+| Query built-in Workers metrics with GraphQL | [Querying Workers metrics](https://developers.cloudflare.com/analytics/graphql-api/tutorials/querying-workers-metrics/) |
+| Define Analytics Engine fields and call `writeDataPoint()` | [Write data points](https://developers.cloudflare.com/analytics/analytics-engine/get-started/) |
+| Authenticate and query Analytics Engine datasets | [SQL API](https://developers.cloudflare.com/analytics/analytics-engine/sql-api/) |
+| Calculate counts, sums, and averages on sampled events | [Analytics Engine sampling](https://developers.cloudflare.com/analytics/analytics-engine/sampling/) |
+| Implement a Tail consumer and inspect event properties | [Tail handler API](https://developers.cloudflare.com/workers/runtime-apis/handlers/tail/) |
+| Create and manage Logpush jobs | [Logpush API configuration](https://developers.cloudflare.com/logs/logpush/logpush-job/api-configuration/) |
+| Select exported Workers event fields | [Workers Trace Events dataset](https://developers.cloudflare.com/logs/logpush/logpush-job/datasets/account/workers_trace_events/) |
+| Export OTLP logs and traces | [OpenTelemetry export](https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/) |
 
-**Query Workers Metrics**:
-```graphql
-query {
-  viewer {
-    accounts(filter: { accountTag: $accountId }) {
-      workersInvocationsAdaptive(
-        limit: 100
-        filter: {
-          datetime_geq: "2025-01-01T00:00:00Z"
-          datetime_leq: "2025-01-31T23:59:59Z"
-          scriptName: "my-worker"
-        }
-      ) {
-        sum {
-          requests
-          errors
-          subrequests
-        }
-        quantiles {
-          cpuTimeP50
-          cpuTimeP99
-          wallTimeP50
-          wallTimeP99
-        }
-      }
-    }
-  }
-}
-```
+Keep dataset field meanings and units consistent between writers and queries. Follow the SQL reference linked from the SQL API for supported date bucketing and aggregate functions; do not assume another SQL dialect's syntax works here. Account for sampling in averages as well as counts and sums.
 
-### Analytics Engine SQL API
-
-**Endpoint**: `https://api.cloudflare.com/client/v4/accounts/{account_id}/analytics_engine/sql`
-
-**Authentication**: `Authorization: Bearer <API_TOKEN>` (Account Analytics Read permission)
-
-**Common Queries**:
-
-```sql
--- List all datasets
-SHOW TABLES;
-
--- Time-series aggregation (5-minute buckets)
-SELECT
-  intDiv(toUInt32(timestamp), 300) * 300 AS time_bucket,
-  blob1 AS endpoint,
-  SUM(_sample_interval) AS total_requests,
-  AVG(double1) AS avg_response_time_ms
-FROM api_metrics
-WHERE timestamp >= NOW() - INTERVAL '24' HOUR
-GROUP BY time_bucket, endpoint
-ORDER BY time_bucket DESC;
-
--- Top customers by usage
-SELECT
-  index1 AS customer_id,
-  SUM(_sample_interval * double1) AS total_api_calls,
-  AVG(double2) AS avg_response_time_ms
-FROM api_usage
-WHERE timestamp >= NOW() - INTERVAL '7' DAY
-GROUP BY customer_id
-ORDER BY total_api_calls DESC
-LIMIT 100;
-
--- Error rate analysis
-SELECT
-  blob1 AS error_type,
-  COUNT(*) AS occurrences,
-  MAX(timestamp) AS last_seen
-FROM error_tracking
-WHERE timestamp >= NOW() - INTERVAL '1' HOUR
-GROUP BY error_type
-ORDER BY occurrences DESC;
-```
-
-### Console Logging API
-
-**Methods**:
-```typescript
-// Standard methods (all appear in Workers Logs)
-console.log('info message');
-console.info('info message');
-console.warn('warning message');
-console.error('error message');
-console.debug('debug message');
-
-// Structured logging (recommended)
-console.log({
-  level: 'info',
-  user_id: '123',
-  action: 'checkout',
-  amount: 99.99,
-  currency: 'USD'
-});
-```
-
-**Log Levels**: All console methods produce logs; use structured fields for filtering:
-```typescript
-console.log({ 
-  level: 'error', 
-  message: 'Payment failed', 
-  error_code: 'CARD_DECLINED' 
-});
-```
-
-### Analytics Engine Binding Types
-
-```typescript
-interface AnalyticsEngineDataset {
-  writeDataPoint(event: AnalyticsEngineDataPoint): void;
-}
-
-interface AnalyticsEngineDataPoint {
-  // Indexed strings (use for filtering/grouping)
-  indexes?: string[];
-  
-  // Non-indexed strings (metadata, IDs, URLs)
-  blobs?: string[];
-  
-  // Numeric values (counts, durations, amounts)
-  doubles?: number[];
-}
-```
-
-**Field Limits**:
-- Max 20 indexes
-- Max 20 blobs
-- Max 20 doubles
-- Max 25 `writeDataPoint` calls per request
-
-### Tail Consumer Event Type
-
-```typescript
-interface TraceItem {
-  event: TraceEvent;
-  logs: TraceLog[];
-  exceptions: TraceException[];
-  scriptName?: string;
-}
-
-interface TraceEvent {
-  outcome: 'ok' | 'exception' | 'exceededCpu' | 'exceededMemory' | 'unknown';
-  cpuTime: number; // microseconds
-  wallTime: number; // microseconds
-}
-
-interface TraceLog {
-  timestamp: number;
-  level: 'log' | 'info' | 'debug' | 'warn' | 'error';
-  message: any; // string or structured object
-}
-
-interface TraceException {
-  name: string;
-  message: string;
-  timestamp: number;
-}
-```
+See [configuration.md](configuration.md) for setup and [patterns.md](patterns.md) for application-level decisions.

--- a/skills/cloudflare/references/observability/configuration.md
+++ b/skills/cloudflare/references/observability/configuration.md
@@ -1,169 +1,23 @@
-## Configuration Patterns
+# Observability Configuration
 
-### Enable Workers Logs
+Fetch the relevant guide before configuring the selected Worker and deployment environment.
 
-```jsonc
-{
-  "observability": {
-    "enabled": true,
-    "head_sampling_rate": 1  // 100% sampling (default)
-  }
-}
-```
+| Task | Maintained documentation |
+| --- | --- |
+| Enable persisted logs, structured JSON logging, and sampling | [Workers Logs](https://developers.cloudflare.com/workers/observability/logs/workers-logs/) |
+| Enable traces and set their sampling independently of logs | [Workers Traces](https://developers.cloudflare.com/workers/observability/traces/) |
+| Configure a named deployment environment | [Wrangler environments](https://developers.cloudflare.com/workers/wrangler/environments/) and the environment example in [Workers Logs](https://developers.cloudflare.com/workers/observability/logs/workers-logs/) |
+| Bind an Analytics Engine dataset and write its first data point | [Analytics Engine get started](https://developers.cloudflare.com/analytics/analytics-engine/get-started/) |
+| Connect a producer to a Tail Worker | [Configure Tail Workers](https://developers.cloudflare.com/workers/observability/logs/tail-workers/) |
+| Create a Logpush job, configure access, and enable Worker log delivery | [Workers Logpush](https://developers.cloudflare.com/workers/observability/logs/logpush/) |
+| Configure OTLP destinations, authentication, and local persistence | [Exporting OpenTelemetry data](https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/) |
 
-**Best Practice**: Use structured JSON logging for better indexing
+## Setup decisions
 
-```typescript
-// Good - structured logging
-console.log({ 
-  user_id: 123, 
-  action: "login", 
-  status: "success",
-  duration_ms: 45
-});
+- Confirm which account, Worker, and environment will emit telemetry, then deploy that configuration and generate representative traffic.
+- Decide log and trace sampling separately. Increasing sampling during an investigation changes volume and cost; restore the intended operational settings afterwards.
+- For Tail Workers, configure the consumer relationship on the producer Worker; use the guide for deployment order and the handler contract.
+- Choose whether to persist data in Cloudflare as well as exporting it. Verify destination names, supported signal types, and credentials using the export guide.
+- Use stable structured fields and redact secrets and unnecessary personal data before emission. Configure development and production collection intentionally.
 
-// Avoid - unstructured string
-console.log("user_id: 123 logged in successfully in 45ms");
-```
-
-### Enable Workers Traces
-
-```jsonc
-{
-  "observability": {
-    "traces": {
-      "enabled": true,
-      "head_sampling_rate": 0.05  // 5% sampling
-    }
-  }
-}
-```
-
-**Note**: Default sampling is 100%. For high-traffic Workers, use lower sampling (0.01-0.1).
-
-### Configure Analytics Engine
-
-**Bind to Worker**:
-```toml
-# wrangler.toml
-analytics_engine_datasets = [
-  { binding = "ANALYTICS", dataset = "api_metrics" }
-]
-```
-
-**Write Data Points**:
-```typescript
-export interface Env {
-  ANALYTICS: AnalyticsEngineDataset;
-}
-
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    // Track metrics
-    env.ANALYTICS.writeDataPoint({
-      blobs: ['customer_123', 'POST', '/api/v1/users'],
-      doubles: [1, 245.5], // request_count, response_time_ms
-      indexes: ['customer_123'] // for efficient filtering
-    });
-    
-    return new Response('OK');
-  }
-}
-```
-
-### Configure Tail Workers
-
-Tail Workers receive logs/traces from other Workers for filtering, transformation, or export.
-
-**Setup**:
-```toml
-# wrangler.toml
-name = "log-processor"
-main = "src/tail.ts"
-
-[[tail_consumers]]
-service = "my-worker" # Worker to tail
-```
-
-**Tail Worker Example**:
-```typescript
-export default {
-  async tail(events: TraceItem[], env: Env, ctx: ExecutionContext) {
-    // Filter errors only
-    const errors = events.filter(event => 
-      event.outcome === 'exception' || event.outcome === 'exceededCpu'
-    );
-    
-    if (errors.length > 0) {
-      // Send to external monitoring
-      ctx.waitUntil(
-        fetch('https://monitoring.example.com/errors', {
-          method: 'POST',
-          body: JSON.stringify(errors)
-        })
-      );
-    }
-  }
-}
-```
-
-### Configure Logpush
-
-Send logs to external storage (S3, R2, GCS, Azure, Datadog, etc.). Requires Business/Enterprise plan.
-
-**Via Dashboard**:
-1. Navigate to Analytics → Logs → Logpush
-2. Select destination type
-3. Provide credentials and bucket/endpoint
-4. Choose dataset (e.g., Workers Trace Events)
-5. Configure filters and fields
-
-**Via API**:
-```bash
-curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/logpush/jobs" \
-  -H "Authorization: Bearer <API_TOKEN>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "workers-logs-to-s3",
-    "destination_conf": "s3://my-bucket/logs?region=us-east-1",
-    "dataset": "workers_trace_events",
-    "enabled": true,
-    "frequency": "high",
-    "filter": "{\"where\":{\"and\":[{\"key\":\"ScriptName\",\"operator\":\"eq\",\"value\":\"my-worker\"}]}}"
-  }'
-```
-
-### Environment-Specific Configuration
-
-**Development** (verbose logs, full sampling):
-```jsonc
-// wrangler.dev.jsonc
-{
-  "observability": {
-    "enabled": true,
-    "head_sampling_rate": 1.0,
-    "traces": {
-      "enabled": true
-    }
-  }
-}
-```
-
-**Production** (reduced sampling, structured logs):
-```jsonc
-// wrangler.prod.jsonc
-{
-  "observability": {
-    "enabled": true,
-    "head_sampling_rate": 0.1, // 10% sampling
-    "traces": {
-      "enabled": true
-    }
-  }
-}
-```
-
-Deploy with env-specific config:
-```bash
-wrangler deploy --config wrangler.prod.jsonc --env production
-```
+See [gotchas.md](gotchas.md) when configured telemetry is missing.

--- a/skills/cloudflare/references/observability/gotchas.md
+++ b/skills/cloudflare/references/observability/gotchas.md
@@ -1,115 +1,25 @@
-## Common Errors
+# Observability Troubleshooting and Constraints
 
-### "Logs not appearing"
+## Missing or incomplete data
 
-**Cause:** Observability disabled, Worker not redeployed, no traffic, low sampling rate, or log size exceeds 256 KB
-**Solution:** 
-```bash
-# Verify config
-cat wrangler.jsonc | jq '.observability'
+| Symptom | Check and authoritative guide |
+| --- | --- |
+| Logs missing from the dashboard | Confirm the deployed Worker/environment, collection and persistence settings, recent traffic, query time range, and sampling. Follow [Workers Logs](https://developers.cloudflare.com/workers/observability/logs/workers-logs/) and [Query Builder](https://developers.cloudflare.com/workers/observability/query-builder/). |
+| Live logs differ from stored logs | Confirm which workflow is being inspected; live streams can sample under load. See [real-time logs](https://developers.cloudflare.com/workers/observability/logs/real-time-logs/). |
+| Traces missing or incomplete | Check trace enablement and sampling separately from logs, then consult [tracing setup](https://developers.cloudflare.com/workers/observability/traces/) and [known limitations](https://developers.cloudflare.com/workers/observability/traces/known-limitations/). |
+| Export destination has no data | Check signal type, destination name, credentials, endpoint compatibility, and provider status using [OpenTelemetry export](https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/). For a Logpush job, use [Workers Logpush](https://developers.cloudflare.com/workers/observability/logs/logpush/). |
+| Tail consumer receives no events | Check the producer's consumer configuration and deployment using [Tail Workers](https://developers.cloudflare.com/workers/observability/logs/tail-workers/). |
+| Analytics Engine totals or averages look wrong | Account for sample weights and consistent field meanings using [sampling guidance](https://developers.cloudflare.com/analytics/analytics-engine/sampling/). Check [limits](https://developers.cloudflare.com/analytics/analytics-engine/limits/) for missing writes or expired data. |
+| Very short operations appear to take no time | Read [performance and timers](https://developers.cloudflare.com/workers/runtime-apis/performance/) and [trace limitations](https://developers.cloudflare.com/workers/observability/traces/known-limitations/). Tracing does not eliminate the runtime's timing restrictions. |
 
-# Check deployment
-wrangler deployments list <WORKER_NAME>
+## Limits, retention, and cost
 
-# Test with curl
-curl https://your-worker.workers.dev
-```
-Ensure `observability.enabled = true`, redeploy Worker, check `head_sampling_rate`, verify traffic
+Fetch these pages when estimating cost or diagnosing truncation and missing data:
 
-### "Traces not being captured"
+- [Workers Logs](https://developers.cloudflare.com/workers/observability/logs/workers-logs/): log size, retention, sampling, and pricing.
+- [Workers Traces](https://developers.cloudflare.com/workers/observability/traces/) and [known limitations](https://developers.cloudflare.com/workers/observability/traces/known-limitations/): availability, propagation, and instrumentation constraints.
+- [Workers pricing](https://developers.cloudflare.com/workers/platform/pricing/): current observability and Tail Worker billing terms.
+- [Analytics Engine limits](https://developers.cloudflare.com/analytics/analytics-engine/limits/) and [pricing](https://developers.cloudflare.com/analytics/analytics-engine/pricing/): field/write limits, retention, query costs, and billing availability.
+- [Workers Logpush](https://developers.cloudflare.com/workers/observability/logs/logpush/): Workers-specific eligibility, permissions, and pricing.
 
-**Cause:** Traces not enabled, incorrect sampling rate, Worker not redeployed, or destination unavailable
-**Solution:**
-```jsonc
-// Temporarily set to 100% sampling for debugging
-{
-  "observability": {
-    "enabled": true,
-    "head_sampling_rate": 1.0,
-    "traces": {
-      "enabled": true
-    }
-  }
-}
-```
-Ensure `observability.traces.enabled = true`, set `head_sampling_rate` to 1.0 for testing, redeploy, check destination status
-
-## Limits
-
-| Resource/Limit | Value | Notes |
-|----------------|-------|-------|
-| Max log size | 256 KB | Logs exceeding this are truncated |
-| Default sampling rate | 1.0 (100%) | Reduce for high-traffic Workers |
-| Max destinations | Varies by plan | Check dashboard |
-| Trace context propagation | 100 spans max | Deep call chains may lose spans |
-| Analytics Engine write rate | 25 writes/request | Excess writes dropped silently |
-
-## Performance Gotchas
-
-### Spectre Mitigation Timing
-
-**Problem:** `Date.now()` and `performance.now()` have reduced precision (coarsened to 100μs)
-**Cause:** Spectre vulnerability mitigation in V8
-**Solution:** Accept reduced precision or use Workers Traces for accurate timing
-```typescript
-// Date.now() is coarsened - trace spans are accurate
-export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    // For user-facing timing, Date.now() is fine
-    const start = Date.now();
-    const response = await processRequest(request);
-    const duration = Date.now() - start;
-    
-    // For detailed performance analysis, use Workers Traces instead
-    return response;
-  }
-}
-```
-
-### Analytics Engine _sample_interval Aggregation
-
-**Problem:** Queries return incorrect totals when not multiplying by `_sample_interval`
-**Cause:** Analytics Engine stores sampled data points, each representing multiple events
-**Solution:** Always multiply counts/sums by `_sample_interval` in aggregations
-```sql
--- WRONG: Undercounts actual events
-SELECT blob1 AS customer_id, COUNT(*) AS total_calls
-FROM api_usage GROUP BY customer_id;
-
--- CORRECT: Accounts for sampling
-SELECT blob1 AS customer_id, SUM(_sample_interval) AS total_calls
-FROM api_usage GROUP BY customer_id;
-```
-
-### Trace Context Propagation Limits
-
-**Problem:** Deep call chains lose trace context after 100 spans
-**Cause:** Cloudflare limits trace depth to prevent performance impact
-**Solution:** Design for flatter architectures or use custom correlation IDs for deep chains
-```typescript
-// For deep call chains, add custom correlation ID
-const correlationId = crypto.randomUUID();
-console.log({ correlationId, event: 'request_start' });
-
-// Pass correlationId through headers to downstream services
-await fetch('https://api.example.com', {
-  headers: { 'X-Correlation-ID': correlationId }
-});
-```
-
-## Pricing (2026)
-
-### Workers Traces
-- **GA Pricing (starts March 1, 2026):**
-  - $0.10 per 1M trace spans captured
-  - Retention: 14 days included
-- **Free tier:** 10M trace spans/month
-- **Note:** Beta usage (before March 1, 2026) is free
-
-### Workers Logs
-- **Included:** Free for all Workers
-- **Logpush:** Requires Business/Enterprise plan
-
-### Analytics Engine
-- **Included:** 10M writes/month on Paid Workers plan
-- **Additional:** $0.25 per 1M writes beyond included quota
+Sampling reduces coverage as well as volume. Do not interpret the absence of a sampled event as proof that an error did not happen. Keep required diagnostic context while avoiding credentials, full sensitive URLs, and unnecessary personal data in logs, custom dimensions, and exported records.

--- a/skills/cloudflare/references/observability/patterns.md
+++ b/skills/cloudflare/references/observability/patterns.md
@@ -1,105 +1,14 @@
 # Observability Patterns
 
-## Usage-Based Billing
+Use these decisions alongside the linked implementation guides. Application event schemas, billing policies, alert thresholds, and delivery behavior still need to be designed for the application.
 
-```typescript
-env.ANALYTICS.writeDataPoint({
-  blobs: [customerId, request.url, request.method],
-  doubles: [1], // request_count
-  indexes: [customerId]
-});
-```
+| Task | Design decision and documentation |
+| --- | --- |
+| Usage-based billing | Define the billable event, tenant identity, time window, and accuracy requirements. Start with the maintained [Analytics Engine billing recipe](https://developers.cloudflare.com/analytics/analytics-engine/recipes/usage-based-billing-for-your-saas-product/) and [sampling guidance](https://developers.cloudflare.com/analytics/analytics-engine/sampling/); assess whether sampled estimates satisfy the billing contract. |
+| Performance monitoring | Use [built-in metrics](https://developers.cloudflare.com/workers/observability/metrics-and-analytics/) for aggregate health and [traces](https://developers.cloudflare.com/workers/observability/traces/) to investigate dependency latency. Custom measurements need consistent units and aggregation semantics; check [runtime timers](https://developers.cloudflare.com/workers/runtime-apis/performance/) before measuring CPU-only work. |
+| Error tracking | Emit structured context without secrets, investigate with [Query Builder](https://developers.cloudflare.com/workers/observability/query-builder/), and choose [Tail Workers](https://developers.cloudflare.com/workers/observability/logs/tail-workers/) if custom alert processing is needed. Define thresholds and duplicate handling for your alert destination. |
+| Multi-tenant tracking | Choose the tenant dimension and consistent field positions using [Analytics Engine get started](https://developers.cloudflare.com/analytics/analytics-engine/get-started/) and [sampling guidance](https://developers.cloudflare.com/analytics/analytics-engine/sampling/). Enforce tenant authorization in the application that exposes analytics; a dataset index is not an access-control boundary. |
+| Tail Worker filtering | Use the current [Tail handler schema](https://developers.cloudflare.com/workers/runtime-apis/handlers/tail/) for outcomes, exceptions, and timing fields, with [Tail configuration](https://developers.cloudflare.com/workers/observability/logs/tail-workers/) for producer wiring. Define filtering, redaction, and downstream failure handling for the destination. |
+| OpenTelemetry export | Prefer the maintained [OTLP export integration](https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/) for supported destinations. For Honeycomb, follow [Export to Honeycomb](https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/honeycomb/) instead of synthesizing spans from Tail events. |
 
-```sql
-SELECT blob1 AS customer_id, SUM(_sample_interval * double1) AS total_calls
-FROM api_usage WHERE timestamp >= DATE_TRUNC('month', NOW())
-GROUP BY customer_id
-```
-
-## Performance Monitoring
-
-```typescript
-const start = Date.now();
-const response = await fetch(url);
-env.ANALYTICS.writeDataPoint({
-  blobs: [url, response.status.toString()],
-  doubles: [Date.now() - start, response.status]
-});
-```
-
-```sql
-SELECT blob1 AS url, AVG(double1) AS avg_ms, percentile(double1, 0.95) AS p95_ms
-FROM fetch_metrics WHERE timestamp >= NOW() - INTERVAL '1' HOUR
-GROUP BY url
-```
-
-## Error Tracking
-
-```typescript
-env.ANALYTICS.writeDataPoint({
-  blobs: [error.name, request.url, request.method],
-  doubles: [1],
-  indexes: [error.name]
-});
-```
-
-## Multi-Tenant Tracking
-
-```typescript
-env.ANALYTICS.writeDataPoint({
-  indexes: [tenantId], // efficient filtering
-  blobs: [tenantId, url.pathname, method, status],
-  doubles: [1, duration, bytesSize]
-});
-```
-
-## Tail Worker Log Filtering
-
-```typescript
-export default {
-  async tail(events, env, ctx) {
-    const critical = events.filter(e => 
-      e.exceptions.length > 0 || e.event.wallTime > 1000000
-    );
-    if (critical.length === 0) return;
-    
-    ctx.waitUntil(
-      fetch('https://logging.example.com/ingest', {
-        method: 'POST',
-        headers: { 'Authorization': `Bearer ${env.API_KEY}` },
-        body: JSON.stringify(critical.map(e => ({
-          outcome: e.event.outcome,
-          cpu_ms: e.event.cpuTime / 1000,
-          errors: e.exceptions
-        })))
-      })
-    );
-  }
-};
-```
-
-## OpenTelemetry Export
-
-```typescript
-export default {
-  async tail(events, env, ctx) {
-    const otelSpans = events.map(e => ({
-      traceId: generateId(32),
-      spanId: generateId(16),
-      name: e.scriptName || 'worker.request',
-      attributes: [
-        { key: 'worker.outcome', value: { stringValue: e.event.outcome } },
-        { key: 'worker.cpu_time_us', value: { intValue: String(e.event.cpuTime) } }
-      ]
-    }));
-    
-    ctx.waitUntil(
-      fetch('https://api.honeycomb.io/v1/traces', {
-        method: 'POST',
-        headers: { 'X-Honeycomb-Team': env.HONEYCOMB_KEY },
-        body: JSON.stringify({ resourceSpans: [{ scopeSpans: [{ spans: otelSpans }] }] })
-      })
-    );
-  }
-};
-```
+Use [Workers Logpush](https://developers.cloudflare.com/workers/observability/logs/logpush/) when the requirement is Workers Trace Event delivery to a supported log destination. Use a Tail Worker when custom processing is required beyond the configured export integration.


### PR DESCRIPTION
The Observability references currently describe Workers Logs as real-time-only and unlimited/free, copy inaccurate Tail event types, and maintain their own configuration, SQL, export examples, and pricing tables. Replace those copies with task-specific routes to maintained Cloudflare documentation while preserving the choice between logs, traces, metrics, Analytics Engine, Tail Workers, Logpush, and OpenTelemetry export.

All five reference paths remain available. Application guidance retains sampling, tenant identity, billing accuracy, redaction, and export decisions; Honeycomb export now routes to the native OTLP integration instead of constructing incomplete spans from Tail events. The bundle shrinks from 641 to 109 lines.

Validation: reviewed the linked official pages for topic coverage, checked all 10 local links and inbound reference paths (no affected fragments), and ran `git diff --check`. Documentation only; no runtime tests required. Related to the focused documentation-routing approach in #122 and the broader refactor in #70.
