### PR TITLE
docs(vectorize): replace copied recipes with documentation routes

### DIFF
--- a/skills/cloudflare/references/vectorize/README.md
+++ b/skills/cloudflare/references/vectorize/README.md
@@ -1,133 +1,22 @@
 # Cloudflare Vectorize
 
-Globally distributed vector database for AI applications. Store and query vector embeddings for semantic search, recommendations, RAG, and classification.
+Use Vectorize when you need to control embeddings, vector indexing, and retrieval for semantic search, recommendations, or RAG. For a managed retrieval pipeline, see [AI Search](../ai-search/README.md).
 
-**Status:** Generally Available (GA) | **Last Updated:** 2026-01-27
+Fetch current documentation before implementing. Start with the [Vectorize documentation index](https://developers.cloudflare.com/vectorize/llms.txt) to discover pages; load only those relevant to the task. Treat the docs as the source of truth for APIs, configuration, models, limits, and pricing.
 
-## Quick Start
+## Task routing
 
-```typescript
-// 1. Create index
-// npx wrangler vectorize create my-index --dimensions=768 --metric=cosine
+| Task | Read |
+|------|------|
+| Create an index and connect a Worker | [Configuration](configuration.md) and [Introduction to Vectorize](https://developers.cloudflare.com/vectorize/get-started/intro/) |
+| Insert, update, query, retrieve, or delete vectors | [API routes](api.md) |
+| Generate embeddings, build RAG, or partition tenant data | [Patterns](patterns.md) |
+| Diagnose missing matches, metadata, or rejected requests | [Gotchas](gotchas.md) |
 
-// 2. Configure binding (wrangler.jsonc)
-// { "vectorize": [{ "binding": "VECTORIZE", "index_name": "my-index" }] }
+## Decisions to make first
 
-// 3. Query vectors
-const matches = await env.VECTORIZE.query(queryVector, { topK: 5 });
-```
-
-## Key Features
-
-- **10M vectors per index** (V2)
-- Dimensions up to 1536 (32-bit float)
-- Three distance metrics: cosine, euclidean, dot-product
-- Metadata filtering (up to 10 indexes)
-- Namespace support (50K namespaces paid, 1K free)
-- Seamless Workers AI integration
-- Global distribution
-
-## Reading Order
-
-| Task | Files to Read |
-|------|---------------|
-| New to Vectorize | README only |
-| Implement feature | README + api + patterns |
-| Setup/configure | README + configuration |
-| Debug issues | gotchas |
-| Integrate with AI | README + patterns |
-| RAG implementation | README + patterns |
-
-## File Guide
-
-- **README.md** (this file): Overview, quick decisions
-- **api.md**: Runtime API, types, operations (query/insert/upsert)
-- **configuration.md**: Setup, CLI, metadata indexes
-- **patterns.md**: RAG, Workers AI, OpenAI, LangChain, multi-tenant
-- **gotchas.md**: Limits, pitfalls, troubleshooting
-
-## Distance Metric Selection
-
-Choose based on your use case:
-
-```
-What are you building?
-├─ Text/semantic search → cosine (most common)
-├─ Image similarity → euclidean
-├─ Recommendation system → dot-product
-└─ Pre-normalized vectors → dot-product
-```
-
-| Metric | Best For | Score Interpretation |
-|--------|----------|---------------------|
-| `cosine` | Text embeddings, semantic similarity | Higher = closer (1.0 = identical) |
-| `euclidean` | Absolute distance, spatial data | Lower = closer (0.0 = identical) |
-| `dot-product` | Recommendations, normalized vectors | Higher = closer |
-
-**Note:** Index configuration is immutable. Cannot change dimensions or metric after creation.
-
-## Multi-Tenancy Strategy
-
-```
-How many tenants?
-├─ < 50K tenants → Use namespaces (recommended)
-│   ├─ Fastest (filter before vector search)
-│   └─ Strict isolation
-├─ > 50K tenants → Use metadata filtering
-│   ├─ Slower (post-filter after vector search)
-│   └─ Requires metadata index
-└─ Per-tenant indexes → Only if compliance mandated
-    └─ 50K index limit per account (paid plan)
-```
-
-## Common Workflows
-
-### Semantic Search
-
-```typescript
-// 1. Generate embedding
-const result = await env.AI.run("@cf/baai/bge-base-en-v1.5", { text: [query] });
-
-// 2. Query Vectorize
-const matches = await env.VECTORIZE.query(result.data[0], {
-  topK: 5,
-  returnMetadata: "indexed"
-});
-```
-
-### RAG Pattern
-
-```typescript
-// 1. Generate query embedding
-const embedding = await env.AI.run("@cf/baai/bge-base-en-v1.5", { text: [query] });
-
-// 2. Search Vectorize
-const matches = await env.VECTORIZE.query(embedding.data[0], { topK: 5 });
-
-// 3. Fetch full documents from R2/D1/KV
-const docs = await Promise.all(matches.matches.map(m => 
-  env.R2.get(m.metadata.key).then(obj => obj?.text())
-));
-
-// 4. Generate LLM response with context
-const answer = await env.AI.run("@cf/meta/llama-3-8b-instruct", {
-  prompt: `Context: ${docs.join("\n\n")}\n\nQuestion: ${query}\n\nAnswer:`
-});
-```
-
-## Critical Gotchas
-
-See `gotchas.md` for details. Most important:
-
-1. **Async mutations**: Inserts take 5-10s to be queryable
-2. **500 batch limit**: Workers API enforces 500 vectors per call (undocumented)
-3. **Metadata truncation**: `"indexed"` returns first 64 bytes only
-4. **topK with metadata**: Max 20 (not 100) when using returnValues or returnMetadata: "all"
-5. **Metadata indexes first**: Must create before inserting vectors
-
-## Resources
-
-- [Official Docs](https://developers.cloudflare.com/vectorize/)
-- [Client API Reference](https://developers.cloudflare.com/vectorize/reference/client-api/)
-- [Workers AI Models](https://developers.cloudflare.com/workers-ai/models/#text-embeddings)
-- [Discord: #vectorize](https://discord.cloudflare.com)
+- Use a consistent embedding model and preprocessing for stored vectors and queries. Matching dimensions alone does not make different models' embeddings compatible.
+- Choose dimensions from the embedding output and a distance metric appropriate to that model. Changing either requires a new index; check [index configuration and scoring semantics](https://developers.cloudflare.com/vectorize/best-practices/create-indexes/) before choosing thresholds.
+- Plan filterable metadata before ingestion. Adding an index later requires re-upserting existing vectors to index that metadata; see [metadata filtering](https://developers.cloudflare.com/vectorize/reference/metadata-filtering/).
+- A namespace partitions search; your application must authorize access and derive tenant scope from trusted identity. See [tenant patterns](patterns.md).
+- Design for asynchronous mutation visibility rather than assuming a completed write is already searchable. See [mutation semantics](https://developers.cloudflare.com/vectorize/reference/client-api/).

--- a/skills/cloudflare/references/vectorize/api.md
+++ b/skills/cloudflare/references/vectorize/api.md
@@ -1,88 +1,18 @@
-# Vectorize API Reference
+# Vectorize API routes
 
-## Types
+Fetch the relevant section of the [Workers binding API](https://developers.cloudflare.com/vectorize/reference/client-api/) before writing calls or types.
 
-```typescript
-interface VectorizeVector {
-  id: string;                    // Max 64 bytes
-  values: number[];              // Must match index dimensions
-  namespace?: string;            // Optional partition (max 64 bytes)
-  metadata?: Record<string, any>; // Max 10 KiB
-}
-```
+| Task | Current documentation |
+|------|-----------------------|
+| Vector shape, binding, and generated TypeScript types | [Vectorize API](https://developers.cloudflare.com/vectorize/reference/client-api/) |
+| Insert, upsert, retrieve by ID, delete, or inspect an index | [Operations](https://developers.cloudflare.com/vectorize/reference/client-api/#operations) |
+| Query by vector or ID; choose returned metadata, values, and scoring precision | [Query vectors](https://developers.cloudflare.com/vectorize/best-practices/query-vectors/) and [query options](https://developers.cloudflare.com/vectorize/reference/client-api/#query-vectors) |
+| Filter by metadata, combine conditions, or use nested properties | [Metadata filtering](https://developers.cloudflare.com/vectorize/reference/metadata-filtering/) |
+| Batch ingestion and select vector formats | [Insert vectors](https://developers.cloudflare.com/vectorize/best-practices/insert-vectors/) and [current limits](https://developers.cloudflare.com/vectorize/platform/limits/) |
+| Manage indexes or vectors outside a Worker | [Wrangler commands](https://developers.cloudflare.com/vectorize/reference/wrangler-commands/) and [REST API](https://developers.cloudflare.com/api/resources/vectorize/subresources/indexes/methods/list/) |
 
-## Query
+## Operation choices
 
-```typescript
-const matches = await env.VECTORIZE.query(queryVector, {
-  topK: 10,                        // Max 100 (or 20 with returnValues/returnMetadata:"all")
-  returnMetadata: "indexed",       // "none" | "indexed" | "all"
-  returnValues: false,
-  namespace: "tenant-123",
-  filter: { category: "docs" }
-});
-// matches.matches[0] = { id, score, metadata? }
-```
-
-**returnMetadata:** `"none"` (fastest) → `"indexed"` (recommended) → `"all"` (topK max 20)
-
-**queryById (V2 only):** Search using existing vector as query.
-```typescript
-await env.VECTORIZE.queryById("doc-123", { topK: 5 });
-```
-
-## Insert/Upsert
-
-```typescript
-// Insert: ignores duplicates (keeps first)
-await env.VECTORIZE.insert([{ id, values, metadata }]);
-
-// Upsert: overwrites duplicates (keeps last)
-await env.VECTORIZE.upsert([{ id, values, metadata }]);
-```
-
-**Max 1,000 vectors per call (Workers) / 5,000 (HTTP API).** Queryable after 5-10 seconds.
-
-## Other Operations
-
-```typescript
-// Get by IDs
-const vectors = await env.VECTORIZE.getByIds(["id1", "id2"]);
-
-// Delete (max 1000 IDs per call)
-await env.VECTORIZE.deleteByIds(["id1", "id2"]);
-
-// Index info
-const info = await env.VECTORIZE.describe();
-// { dimensions, metric, vectorCount }
-```
-
-## Filtering
-
-Requires metadata index. Filter operators:
-
-| Operator | Example |
-|----------|---------|
-| `$eq` (implicit) | `{ category: "docs" }` |
-| `$ne` | `{ status: { $ne: "deleted" } }` |
-| `$in` / `$nin` | `{ tag: { $in: ["sale"] } }` |
-| `$lt`, `$lte`, `$gt`, `$gte` | `{ price: { $lt: 100 } }` |
-
-**Constraints:** Max 2048 bytes, no dots/`$` in keys, values: string/number/boolean/null.
-
-## Performance
-
-| Configuration | topK Limit | Speed |
-|--------------|------------|-------|
-| No metadata | 100 | Fastest |
-| `returnMetadata: "indexed"` | 100 | Fast |
-| `returnMetadata: "all"` | 20 | Slower |
-| `returnValues: true` | 20 | Slower |
-
-**Batch operations:** Always batch (1,000/call via Workers, 5,000 via HTTP API) for optimal throughput.
-
-```typescript
-for (let i = 0; i < vectors.length; i += 1000) {
-  await env.VECTORIZE.upsert(vectors.slice(i, i + 1000));
-}
-```
+- Choose insert when existing IDs should be preserved; choose upsert when they should be replaced. Upsert replaces the whole vector, including metadata, so provide the complete intended record.
+- Request only the values and metadata the caller needs. Indexed metadata can omit fields or truncate strings; full metadata and vector values change query limits and latency. Fetch the current query options before choosing a result count.
+- Treat accepted mutations and query visibility as separate events. Use current mutation guidance when implementing ingestion verification or read-after-write behavior.

--- a/skills/cloudflare/references/vectorize/configuration.md
+++ b/skills/cloudflare/references/vectorize/configuration.md
@@ -1,88 +1,19 @@
-# Vectorize Configuration
+# Vectorize configuration routes
 
-## Create Index
+| Task | Current documentation |
+|------|-----------------------|
+| Create an index, choose dimensions and metric | [Create indexes](https://developers.cloudflare.com/vectorize/best-practices/create-indexes/) |
+| Bind an index to a Worker, develop, deploy, and verify queries | [Introduction to Vectorize](https://developers.cloudflare.com/vectorize/get-started/intro/) |
+| Configure bindings and generate types | [Binding and TypeScript guidance](https://developers.cloudflare.com/vectorize/reference/client-api/#binding-to-a-worker) |
+| Create, list, or delete metadata indexes | [Metadata filtering](https://developers.cloudflare.com/vectorize/reference/metadata-filtering/) and [Wrangler commands](https://developers.cloudflare.com/vectorize/reference/wrangler-commands/) |
+| Manage indexes and vectors through the CLI | [Wrangler commands](https://developers.cloudflare.com/vectorize/reference/wrangler-commands/) |
+| Upload NDJSON and batch ingestion | [Insert vectors](https://developers.cloudflare.com/vectorize/best-practices/insert-vectors/) |
+| Check capacity, payload, namespace, or batch constraints | [Limits](https://developers.cloudflare.com/vectorize/platform/limits/) |
 
-```bash
-npx wrangler vectorize create my-index --dimensions=768 --metric=cosine
-```
+## Configuration decisions
 
-**⚠️ Dimensions and metric are immutable** - cannot change after creation.
+Confirm the embedding model, output dimensions, and distance metric before provisioning: dimensions and metric cannot be changed in place. Plan a new index and re-embedding where needed when changing models.
 
-## Worker Binding
+Create metadata indexes before ingesting vectors that must be filterable. If adding one to an existing dataset, plan to re-upsert the affected vectors after index creation.
 
-```jsonc
-// wrangler.jsonc
-{
-  "vectorize": [
-    { "binding": "VECTORIZE", "index_name": "my-index" }
-  ]
-}
-```
-
-```typescript
-interface Env {
-  VECTORIZE: Vectorize;
-}
-```
-
-## Metadata Indexes
-
-**Must create BEFORE inserting vectors** - existing vectors not retroactively indexed.
-
-```bash
-wrangler vectorize create-metadata-index my-index --property-name=category --type=string
-wrangler vectorize create-metadata-index my-index --property-name=price --type=number
-```
-
-| Type | Use For |
-|------|---------|
-| `string` | Categories, tags (first 64 bytes indexed) |
-| `number` | Prices, timestamps |
-| `boolean` | Flags |
-
-## CLI Commands
-
-```bash
-# Index management
-wrangler vectorize list
-wrangler vectorize info <index-name>
-wrangler vectorize delete <index-name>
-
-# Vector operations
-wrangler vectorize insert <index-name> --file=embeddings.ndjson
-wrangler vectorize get <index-name> --ids=id1,id2
-wrangler vectorize delete-by-ids <index-name> --ids=id1,id2
-
-# Metadata indexes
-wrangler vectorize list-metadata-index <index-name>
-wrangler vectorize delete-metadata-index <index-name> --property-name=field
-```
-
-## Bulk Upload (NDJSON)
-
-```json
-{"id": "1", "values": [0.1, 0.2, ...], "metadata": {"category": "docs"}}
-{"id": "2", "values": [0.4, 0.5, ...], "namespace": "tenant-abc"}
-```
-
-**Limits:** 5000 vectors per file, 100 MB max
-
-## Cardinality Best Practice
-
-Bucket high-cardinality data:
-```typescript
-// ❌ Millisecond timestamps
-metadata: { timestamp: Date.now() }
-
-// ✅ 5-minute buckets
-metadata: { timestamp_bucket: Math.floor(Date.now() / 300000) * 300000 }
-```
-
-## Production Checklist
-
-1. Create index with correct dimensions
-2. Create metadata indexes FIRST
-3. Test bulk upload
-4. Configure bindings
-5. Deploy Worker
-6. Verify queries
+Choose metadata granularity around actual queries. For range filters over high-cardinality fields, consider buckets that preserve the application's required precision; do not bucket identifiers used for exact matches. Fetch the [cardinality guidance](https://developers.cloudflare.com/vectorize/best-practices/insert-vectors/#performance-tips-when-filtering-by-metadata) before designing the schema.

--- a/skills/cloudflare/references/vectorize/gotchas.md
+++ b/skills/cloudflare/references/vectorize/gotchas.md
@@ -1,76 +1,15 @@
-# Vectorize Gotchas
+# Vectorize troubleshooting routes
 
-## Critical Warnings
+Fetch current documentation before diagnosing a numeric limit, API error, or delayed mutation. Do not infer batch sizes or result limits from old snippets.
 
-### Async Mutations
-Insert/upsert/delete return immediately but vectors aren't queryable for 5-10 seconds.
+| Symptom or decision | What to check | Current documentation |
+|---------------------|---------------|-----------------------|
+| A write succeeded but search has not changed | Mutations are asynchronous; acceptance does not guarantee query visibility | [Insert, upsert, and delete semantics](https://developers.cloudflare.com/vectorize/reference/client-api/#operations) |
+| Ingestion is slow or a batch is rejected | Batch size depends on the interface; inspect throughput and payload constraints | [Write throughput](https://developers.cloudflare.com/vectorize/best-practices/insert-vectors/#improve-write-throughput) and [limits](https://developers.cloudflare.com/vectorize/platform/limits/) |
+| Query count is rejected or metadata is incomplete | Returned values and metadata affect query limits; indexed metadata can be truncated | [Query options](https://developers.cloudflare.com/vectorize/reference/client-api/#query-vectors) |
+| Metadata filters return no matches | Confirm field type, operators, nesting, and index creation; re-upsert data written before the metadata index existed | [Metadata filtering](https://developers.cloudflare.com/vectorize/reference/metadata-filtering/) |
+| Query has no matches or poor relevance | Check embedding model and dimensions, metric, namespace, filters, and mutation visibility | [Query vectors](https://developers.cloudflare.com/vectorize/best-practices/query-vectors/) and [index configuration](https://developers.cloudflare.com/vectorize/best-practices/create-indexes/) |
+| Existing IDs or metadata behave unexpectedly on update | Insert preserves existing IDs; upsert replaces the full vector and metadata | [Mutation semantics](https://developers.cloudflare.com/vectorize/reference/client-api/#operations) |
+| Capacity or model output no longer fits | Check current limits and model output dimensions; changing dimensions or metric requires another index | [Limits](https://developers.cloudflare.com/vectorize/platform/limits/) and [create indexes](https://developers.cloudflare.com/vectorize/best-practices/create-indexes/) |
 
-### Batch Size Limit
-**Workers API: 1,000 vectors max per call (HTTP API: 5,000).** Silently truncates if exceeded.
-
-```typescript
-// ✅ Chunk into 1000 (Workers API limit; HTTP API allows 5000)
-for (let i = 0; i < vectors.length; i += 1000) {
-  await env.VECTORIZE.upsert(vectors.slice(i, i + 1000));
-}
-```
-
-### Metadata Truncation
-`returnMetadata: "indexed"` returns only first 64 bytes of strings. Use `"all"` for complete metadata (but max topK drops to 20).
-
-### topK Limits
-
-| returnMetadata | returnValues | Max topK |
-|----------------|--------------|----------|
-| `"none"` / `"indexed"` | `false` | 100 |
-| `"all"` | any | **20** |
-| any | `true` | **20** |
-
-### Metadata Indexes First
-Create BEFORE inserting - existing vectors not retroactively indexed.
-
-```bash
-# ✅ Create index FIRST
-wrangler vectorize create-metadata-index my-index --property-name=category --type=string
-wrangler vectorize insert my-index --file=data.ndjson
-```
-
-### Index Config Immutable
-Cannot change dimensions/metric after creation. Must create new index and migrate.
-
-## Limits (V2)
-
-| Resource | Limit |
-|----------|-------|
-| Vectors per index | 10,000,000 |
-| Max dimensions | 1536 |
-| Batch upsert (Workers / HTTP API) | **1,000 / 5,000** |
-| Indexed string metadata | **64 bytes** |
-| Metadata indexes | 10 |
-| Namespaces | 50,000 (paid) / 1,000 (free) |
-
-## Common Mistakes
-
-1. **Wrong embedding shape:** Extract `result.data[0]` from Workers AI
-2. **Metadata index after data:** Re-upsert all vectors
-3. **Insert vs upsert:** `insert` ignores duplicates, `upsert` overwrites
-4. **Not batching:** Individual inserts ~1K/min, batched ~200K+/min
-
-## Troubleshooting
-
-**No results?**
-- Wait 5-10s after insert
-- Check namespace spelling (case-sensitive)
-- Verify metadata index exists
-- Check dimension mismatch
-
-**Metadata filter not working?**
-- Index must exist before data insert
-- Strings >64 bytes truncated
-- Use dot notation for nested: `"product.category"`
-
-## Model Dimensions
-
-- `@cf/baai/bge-small-en-v1.5`: 384
-- `@cf/baai/bge-base-en-v1.5`: 768
-- `@cf/baai/bge-large-en-v1.5`: 1024
+For changes to embedding providers or tenant boundaries, also read [pattern decisions](patterns.md).

--- a/skills/cloudflare/references/vectorize/patterns.md
+++ b/skills/cloudflare/references/vectorize/patterns.md
@@ -1,90 +1,24 @@
-# Vectorize Patterns
+# Vectorize pattern routes
 
-## Workers AI Integration
+| Task | Current documentation |
+|------|-----------------------|
+| Generate and query Workers AI embeddings | [Vectorize and Workers AI](https://developers.cloudflare.com/vectorize/get-started/embeddings/) |
+| Query with embeddings from OpenAI | [OpenAI integration](https://developers.cloudflare.com/vectorize/best-practices/query-vectors/#openai) |
+| Choose embedding dimensions and distance metric | [Create indexes](https://developers.cloudflare.com/vectorize/best-practices/create-indexes/) |
+| Build a retrieval-augmented generation application | [Workers AI RAG tutorial](https://developers.cloudflare.com/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai/) |
+| Link search results to source documents | [Vector metadata](https://developers.cloudflare.com/vectorize/best-practices/insert-vectors/#metadata) |
+| Partition vectors by tenant | [Namespaces](https://developers.cloudflare.com/vectorize/best-practices/insert-vectors/#namespaces) and [namespace versus metadata filtering](https://developers.cloudflare.com/vectorize/reference/metadata-filtering/#namespace-versus-metadata-filtering) |
+| Combine similarity search with categorical or range filters | [Metadata filtering](https://developers.cloudflare.com/vectorize/reference/metadata-filtering/) |
+| Ingest or update vectors in batches | [Insert vectors](https://developers.cloudflare.com/vectorize/best-practices/insert-vectors/) and [limits](https://developers.cloudflare.com/vectorize/platform/limits/) |
 
-```typescript
-// Generate embedding + query
-const result = await env.AI.run("@cf/baai/bge-base-en-v1.5", { text: [query] });
-const matches = await env.VECTORIZE.query(result.data[0], { topK: 5 }); // Pass data[0]!
-```
+## Embedding and retrieval decisions
 
-| Model | Dimensions |
-|-------|------------|
-| `@cf/baai/bge-small-en-v1.5` | 384 |
-| `@cf/baai/bge-base-en-v1.5` | 768 (recommended) |
-| `@cf/baai/bge-large-en-v1.5` | 1024 |
+Keep ingestion and query embeddings compatible: use the same model and preprocessing, and extract the individual vector from the provider's documented response shape. Fetch the selected model's current documentation for dimensions and input requirements.
 
-## OpenAI Integration
+For RAG, store a reliable reference to the source content and request the metadata needed to resolve it. Handle missing or deleted source documents before passing retrieved context to generation.
 
-```typescript
-const response = await openai.embeddings.create({ model: "text-embedding-ada-002", input: query });
-const matches = await env.VECTORIZE.query(response.data[0].embedding, { topK: 5 });
-```
+## Tenant scope
 
-## RAG Pattern
+Namespaces and metadata filters narrow searches; they do not authenticate the caller. Derive the permitted tenant scope from trusted identity and enforce it on every relevant read and write, including ID-based retrieval and deletion. Do not assume a namespace query option protects other operations.
 
-```typescript
-// 1. Embed query
-const emb = await env.AI.run("@cf/baai/bge-base-en-v1.5", { text: [query] });
-
-// 2. Search vectors
-const matches = await env.VECTORIZE.query(emb.data[0], { topK: 5, returnMetadata: "indexed" });
-
-// 3. Fetch full docs from R2/D1/KV
-const docs = await Promise.all(matches.matches.map(m => env.R2.get(m.metadata.key).then(o => o?.text())));
-
-// 4. Generate with context
-const answer = await env.AI.run("@cf/meta/llama-3-8b-instruct", {
-  prompt: `Context:\n${docs.filter(Boolean).join("\n\n")}\n\nQuestion: ${query}\n\nAnswer:`
-});
-```
-
-## Multi-Tenant
-
-### Namespaces (< 50K tenants, fastest)
-
-```typescript
-await env.VECTORIZE.upsert([{ id: "1", values: emb, namespace: `tenant-${id}` }]);
-await env.VECTORIZE.query(vec, { namespace: `tenant-${id}`, topK: 10 });
-```
-
-### Metadata Filter (> 50K tenants)
-
-```bash
-wrangler vectorize create-metadata-index my-index --property-name=tenantId --type=string
-```
-
-```typescript
-await env.VECTORIZE.upsert([{ id: "1", values: emb, metadata: { tenantId: id } }]);
-await env.VECTORIZE.query(vec, { filter: { tenantId: id }, topK: 10 });
-```
-
-## Hybrid Search
-
-```typescript
-const matches = await env.VECTORIZE.query(vec, {
-  topK: 20,
-  filter: {
-    category: { $in: ["tech", "science"] },
-    published: { $gte: lastMonthTimestamp }
-  }
-});
-```
-
-## Batch Ingestion
-
-```typescript
-const BATCH = 500;
-for (let i = 0; i < vectors.length; i += BATCH) {
-  await env.VECTORIZE.upsert(vectors.slice(i, i + BATCH));
-}
-```
-
-## Best Practices
-
-1. **Pass `data[0]`** not `data` or full response
-2. **Batch 500** vectors per upsert
-3. **Create metadata indexes** before inserting
-4. **Use namespaces** for tenant isolation (faster than filters)
-5. **`returnMetadata: "indexed"`** for best speed/data balance
-6. **Handle 5-10s mutation delay** in async operations
+Choose namespace or metadata partitioning based on the required query scope and current limits. Both narrow the search space; avoid assuming metadata filtering happens after vector search. If tenant IDs are stored in metadata, create the corresponding metadata index before ingestion.


### PR DESCRIPTION
Vectorize references currently copy API examples, configuration, model dimensions, and conflicting or stale limits. Replace those copies with task-specific routes to current Cloudflare documentation, following #122.

Preserve all five reference paths and the decisions needed before implementation: embedding compatibility and immutable index configuration, metadata indexing before ingestion, tenant authorization, full-record upserts, and asynchronous mutation visibility. This removes fixed batch sizes, model tables, and result-limit tables from the skill.

Validation: reviewed linked documentation for coverage of removed topics; fetched all 21 unique documentation URLs and verified their fragments; checked local links and inbound reference fragments; `git diff --check` passed. No runtime tests are applicable to these Markdown-only changes.

This is a focused Vectorize cleanup within the broader scope of #70.
