### PR TITLE
Add Workers AI application inference skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 | sandbox-stable | Sandbox on the current stable `@cloudflare/sandbox` package |
 | sandbox-migrate-to-next | Port a stable Sandbox app to `@cloudflare/sandbox@next` |
 | wrangler | Deploying and managing Workers, KV, R2, D1, Vectorize, Queues, Workflows |
+| workers-ai | Implementing text, structured extraction, embeddings, image, and speech features with Workers AI |
 | workers-best-practices | Writing, reviewing, or configuring production Workers |
 | cloudflare-email-service | Implementing or troubleshooting Email Sending, Email Routing, and delivery configuration |
 | turnstile-spin | Setting up, repairing, or migrating Turnstile bot verification, including server-side Siteverify |

--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -53,7 +53,7 @@ Find the row closest to the user's task. Products can appear in multiple rows, a
 | Process jobs asynchronously or buffer bursts of work | Queues | Decouple producers and consumers; use Workflows for durable multi-step orchestration | [Queues](references/queues/README.md) |
 | Run a job that retries, waits, and resumes across steps | Workflows | Coordinate durable multi-step business processes | [Workflows](references/workflows/README.md) |
 | Start a Worker on a recurring schedule | Cron Triggers | Trigger scheduled work; combine with Queues or Workflows for the work itself | [Cron Triggers](references/cron-triggers/README.md) |
-| Run language, embedding, image, or speech models | Workers AI | Use managed inference; verify model capabilities, schemas, and pricing | [Workers AI](references/workers-ai/README.md) |
+| Run language, embedding, image, or speech models | Workers AI | Use managed inference; verify model capabilities, schemas, and pricing | `workers-ai` skill; [Workers AI](references/workers-ai/README.md) |
 | Add managed search or answers over your content | AI Search | Use a managed retrieval-augmented generation pipeline | [AI Search](references/ai-search/README.md) |
 | Build custom semantic search or retrieval | Vectorize + Workers AI | Control embeddings, indexing, and retrieval rather than using a managed pipeline | [Vectorize](references/vectorize/README.md); [Workers AI](references/workers-ai/README.md) |
 | Observe and control requests to AI providers | AI Gateway | Add inference analytics, caching, and request controls | [AI Gateway](references/ai-gateway/README.md) |

--- a/skills/workers-ai/SKILL.md
+++ b/skills/workers-ai/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: workers-ai
+description: Build or troubleshoot application AI features with Cloudflare Workers AI, including text streaming, structured extraction, embeddings, and image or speech inference. Use for model selection and integration through Workers bindings, REST, or an existing AI SDK; stateful agent orchestration belongs to the Agents SDK.
+---
+
+# Build application features with Workers AI
+
+Implement the requested inference feature in the application's existing architecture. Ordinary generation, extraction, and embeddings do not require an agent framework. Preserve the user's chosen integration and model unless a verified capability gap requires a change.
+
+Fetch the relevant current documentation before implementing. Use the [documentation index](https://developers.cloudflare.com/workers-ai/llms.txt) when the task is not covered below; keep changing model schemas and SDK examples in the docs rather than copying a fixed catalog into the project.
+
+## Choose a model and integration
+
+Inspect the existing request handler, consumer, dependencies, and Worker configuration. Establish the expected output, whether it must stream, and the task's quality, latency, and cost constraints. Open the selected model's page in the [catalog](https://developers.cloudflare.com/workers-ai/models/) and check its exact identifier, input/output schema, context budget, and feature support. A tutorial's example model is not a universal default.
+
+| Application context | Documentation and decision |
+| --- | --- |
+| Worker without an SDK abstraction | Use the [native AI binding](https://developers.cloudflare.com/workers-ai/configuration/bindings/); configure it in the environment actually being run. |
+| Existing Vercel AI SDK application | Preserve its SDK and client protocol; consult the [Workers AI provider integration](https://developers.cloudflare.com/workers-ai/configuration/ai-sdk/) and check installed SDK/provider versions before adapting examples. |
+| External service or script | Follow [REST setup and authentication](https://developers.cloudflare.com/workers-ai/get-started/rest-api/); keep the account token server-side. |
+| Existing OpenAI client | Check [compatible endpoints](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/) for the requested operation and model; compatibility is not a promise that every API or parameter works. |
+
+For local development, follow [Workers and Wrangler setup](https://developers.cloudflare.com/workers-ai/get-started/workers-wrangler/). The Worker can execute locally while inference accesses the Cloudflare account and consumes usage. Do not require remote execution of the entire Worker or describe inference as offline. Distinguish mocked tests from real inference in validation results.
+
+## Implement the requested output
+
+- **Text and streaming:** use the selected model's schema and the chosen integration's response format. Native binding SSE, an SDK text stream, and an SDK UI stream are different contracts; match the actual consumer. Preserve incremental delivery rather than buffering the entire response before returning it.
+- **Extraction and structured output:** read [JSON mode](https://developers.cloudflare.com/workers-ai/features/json-mode/) for supported models, schema format, and streaming restrictions. Validate output against the application's schema and handle failure to satisfy it; prompting for JSON alone does not establish a validated application contract. Do not silently drop the schema to make streaming work.
+- **Embeddings:** inspect the model's dimensions and input limits before connecting an index. Keep query and document embeddings compatible; equal dimensions alone do not make different models interchangeable. A model change may require re-embedding existing content.
+- **Images and audio:** use the task-specific model page for accepted media inputs, encoding, output format, and supported streaming. Do not parse all inference responses as text JSON or assume every speech model supports real-time use.
+
+Keep retrieval and orchestration proportional to the task. Add retrieval when answers need grounding in a corpus, and stateful agents when the application actually needs coordinated state or agent behavior. Gateway request controls are a separate concern; retain any existing Gateway integration.
+
+## Verify the feature
+
+Run the project's relevant type/build checks, then exercise representative inputs through the actual response consumer when inference is available within the task's scope. Verify the behavior that matters: incremental rendering for streams, valid and invalid extraction results for structured output, retrieval compatibility for embeddings, or usable media with the expected content type for image/audio output. Judge model quality on the user's examples, not just a successful HTTP response.
+
+Use [error codes](https://developers.cloudflare.com/workers-ai/platform/errors/) to distinguish configuration or schema failures from transient inference failures. Check [limits](https://developers.cloudflare.com/workers-ai/platform/limits/) and [pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/) for the selected workload before making throughput or cost claims. Bound any retries and retain the original failure when retrying cannot fix it.
+
+Report the integration and model chosen, observed behavior, and which checks used mocks or real inference. If account access prevents inference, finish the local checks and identify that remaining validation explicitly.


### PR DESCRIPTION
Applications needing generation, extraction, or embeddings currently have Workers AI references but no dedicated implementation skill. Add `workers-ai` to guide model selection, preserve native binding/REST/existing SDK integrations, and verify the application's actual output contract without requiring an agent framework. Add discovery entries in the README and Cloudflare product map.

The skill links to current developer docs for model schemas, streaming, JSON mode, integration setup, local development, errors, limits, and pricing. It covers embeddings and media through model-specific documentation and makes clear that local Worker execution still uses remote, usage-consuming inference. Gateway controls remain a separate concern.

Validation: `quick_validate.py` via `uv run --with pyyaml` and `git diff --check` passed. Read the linked documentation content, including JSON mode's streaming restriction and schema-failure behavior, the binding and AI SDK streaming examples, REST authentication, and local development usage. No live inference or deployment was needed for this documentation change. No blocking developer-documentation gaps identified; SDK examples are version-sensitive, so the skill explicitly checks installed versions instead of copying them.
