### PR TITLE
Add Cloudflare Workflows implementation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Skills are contextual and auto-loaded based on your conversation. When a request
 |-------|------------|
 | cloudflare | Helps agents discover which Cloudflare products fit their needs, then find the right skills and docs |
 | agents-sdk | Building stateful AI agents with state, scheduling, RPC, MCP servers, email, and streaming chat |
+| cloudflare-workflows | Durable multi-step jobs, approval flows, scheduled pipelines, retries, and instance debugging |
 | durable-objects | Stateful coordination (chat rooms, games, booking), RPC, SQLite, alarms, WebSockets |
 | sandbox-next | Sandbox on `@cloudflare/sandbox@next` (1.0 preview); recommended for new projects |
 | sandbox-stable | Sandbox on the current stable `@cloudflare/sandbox` package |

--- a/skills/cloudflare-workflows/SKILL.md
+++ b/skills/cloudflare-workflows/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: cloudflare-workflows
+description: Build and debug durable multi-step jobs on Cloudflare Workflows, including approval flows, scheduled pipelines, retries, and resumable business processes. Use when work must persist progress across failures or waits, even if the user does not name Workflows.
+---
+
+# Build durable jobs with Workflows
+
+Turn the requested process into a runnable Workflow, its trigger, and evidence that success and failure paths behave correctly. Preserve the existing framework, language, storage, and deployment setup; inspect pinned dependencies and bindings before changing configuration.
+
+## Choose the execution model
+
+- Choose Workflows when a job must persist progress, retry individual steps, or wait for external input. For recurring instances, check [direct Workflow schedules](https://developers.cloudflare.com/workflows/build/trigger-workflows/) before adding a separate scheduled Worker.
+- Choose [Queues](https://developers.cloudflare.com/queues/) for buffered asynchronous message delivery. A consumer can start a Workflow when each message requires durable orchestration.
+- Choose [Cron Triggers](https://developers.cloudflare.com/workers/configuration/cron-triggers/) when the requirement is scheduled Worker execution; scheduling alone does not define a durable multi-step process.
+- Choose [Durable Objects](https://developers.cloudflare.com/durable-objects/) when shared state and coordination per entity are central. Preserve an existing suitable implementation unless migration is requested.
+
+## Implement the process
+
+Identify the trigger, immutable input, completion result, external effects, and any approval or timeout outcome. Read the relevant current docs before writing code; keep signatures and configuration in the docs rather than copying a starter blindly.
+
+| Decision | Read before implementing |
+| --- | --- |
+| Add a Workflow class and binding to the project | [First Workflow](https://developers.cloudflare.com/workflows/get-started/guide/); [Workers API](https://developers.cloudflare.com/workflows/build/workers-api/) |
+| Start from HTTP, a queue, another Worker, or a schedule | [Trigger Workflows](https://developers.cloudflare.com/workflows/build/trigger-workflows/) |
+| Retry transient failures, stop permanent failures, or delay work | [Sleeping and retrying](https://developers.cloudflare.com/workflows/build/sleeping-and-retrying/) |
+| Wait for approval or a callback | [Events and parameters](https://developers.cloudflare.com/workflows/build/events-and-parameters/) |
+| Inspect or manage a failed instance | [Wrangler commands](https://developers.cloudflare.com/workflows/reference/wrangler-commands/); [metrics and analytics](https://developers.cloudflare.com/workflows/observability/metrics-analytics/) |
+
+Read [Rules of Workflows](https://developers.cloudflare.com/workflows/build/rules-of-workflows/) before choosing step boundaries:
+
+- Split independently retryable effects into steps. Persist state through step returns; do not rely on mutated input or in-memory accumulators surviving replay.
+- Keep step names and branching deterministic from input or persisted results. Await step operations; consult the rules before introducing parallel or racing steps.
+- Make repeated external effects safe using the destination's idempotency guarantees. A successful external write followed by an interrupted step can be attempted again. Check-then-write alone is not an atomic deduplication guarantee.
+
+Configure retries and per-attempt timeouts for the downstream operation. Use the documented non-retryable error mechanism for permanent failures; define an eventual failure outcome rather than retrying indefinitely. Use durable sleep APIs for delays.
+
+For events, distinguish creation parameters from later input. Match the target instance and event type, validate the callback at the application's existing trust boundary, and implement an explicit event-timeout outcome. Return the instance identifier from a trigger and expose status through the existing application interface; successful creation is not successful completion. Consult current creation and retention semantics before treating an instance ID as permanent deduplication.
+
+## Verify and investigate
+
+Use [local development](https://developers.cloudflare.com/workflows/build/local-development/) with the project's supported Wrangler or Vite tooling. Local Explorer can inspect instance status and step history, trigger runs, and send events. Check its version requirements before relying on it. Local Workflows do not support remote bindings or remote development mode.
+
+For automated checks, read the [Workflow test APIs](https://developers.cloudflare.com/workers/testing/vitest-integration/test-apis/#workflows). Configure introspection before triggering instances, await the expected status or step result, and dispose introspectors. Exercise the relevant cases:
+
+- Successful execution and the actual output or persisted effect.
+- A transient failure followed by recovery, and exhausted or permanent failure with useful error evidence.
+- Approval arrival and timeout when events are used.
+- Repeated input or a retried external write without duplicate business effects.
+
+Mock external services when testing retries; replacing the entire effect step with a successful result cannot establish its idempotency. Inspect the failed instance and step before changing limits or restarting work. Restart only when requested or already authorized and the repeated effects are understood. Report what ran locally, what failed, and any hosted behavior still unverified.
+
+For additional examples, capacity, and configuration routes, use the bundled [Workflows documentation map](../cloudflare/references/workflows/README.md) when available, or the [official index](https://developers.cloudflare.com/workflows/llms.txt). Fetch current limits when payload size, concurrency, or retention matters.

--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -51,7 +51,7 @@ Find the row closest to the user's task. Products can appear in multiple rows, a
 | Accelerate an existing website and control cached content | Cache/CDN | Configure caching for a proxied origin using Cache Rules, expiration settings, and purging | [Cache/CDN docs](https://developers.cloudflare.com/cache/) |
 | Keep origin content in a persistent cache | Cache Reserve | Reduce origin fetches with persistent CDN cache storage | [Cache Reserve](references/cache-reserve/README.md) |
 | Process jobs asynchronously or buffer bursts of work | Queues | Decouple producers and consumers; use Workflows for durable multi-step orchestration | [Queues](references/queues/README.md) |
-| Run a job that retries, waits, and resumes across steps | Workflows | Coordinate durable multi-step business processes | [Workflows](references/workflows/README.md) |
+| Run a job that retries, waits, and resumes across steps | Workflows | Coordinate durable multi-step business processes | `cloudflare-workflows` skill; [Workflows](references/workflows/README.md) |
 | Start a Worker on a recurring schedule | Cron Triggers | Trigger scheduled work; combine with Queues or Workflows for the work itself | [Cron Triggers](references/cron-triggers/README.md) |
 | Run language, embedding, image, or speech models | Workers AI | Use managed inference; verify model capabilities, schemas, and pricing | [Workers AI](references/workers-ai/README.md) |
 | Add managed search or answers over your content | AI Search | Use a managed retrieval-augmented generation pipeline | [AI Search](references/ai-search/README.md) |


### PR DESCRIPTION
Requests for approval flows, resumable pipelines, or jobs that retry across failures currently reach product references without a dedicated implementation workflow. Add `cloudflare-workflows` to connect product selection, step design, triggers, event waits, and observable success/failure verification. Register the skill in the README and Cloudflare routing row.

The skill preserves the existing application stack and directs agents to current documentation for APIs and configuration. It includes replay/idempotency invariants, direct Workflow scheduling, Local Explorer inspection, and Vitest introspection with failure and duplicate-effect checks. It reuses the existing Workflows documentation map instead of copying it.

Validation: skill-creator `quick_validate.py` passed; `git diff --check` passed; parent agent reviewed the skill. Read current developer documentation for Workflows rules, triggers, retries, events, local development, test APIs, instance APIs, CLI inspection, metrics, initial setup, and Queues/Cron/Durable Objects selection. No runtime code changed or hosted resources operated.

Documentation note: Rules of Workflows recommends idempotency but its payment example uses a separate check followed by a write. That example alone does not establish atomic deduplication under concurrent attempts. The skill retains the existing reference's destination-idempotency guidance and does not prescribe an unsupported payment implementation. No blocking documentation gaps were found for this skill's scope.
